### PR TITLE
Moved three js dependency from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5637,7 +5637,8 @@
     "three": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^7.25.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.2",
+    "three": "^0.128.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.2"
@@ -45,7 +46,5 @@
   "peerDependencies": {
     "three": "^0.128.0"
   },
-  "dependencies": {
-    "three": "^0.128.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Having an peer dependency in dependecies is error prone since it can introduce two different versions simultaneously. For convenience reasons I duplicated it in dev depencdencies. That way when developing locally you'll get it installed as dev dep and users of the library will only have a peer dep.

This a potentially a breaking change - since users may be not having three as a direct dependency