### PR TITLE
fix three r132.1

### DIFF
--- a/src/content/MSDFText.js
+++ b/src/content/MSDFText.js
@@ -1,6 +1,6 @@
 
 import { Mesh } from 'three';
-import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 
 import MSDFGlyph from './MSDFGlyph.js';
 
@@ -72,7 +72,7 @@ function buildText() {
 
     });
 
-    const mergedGeom = BufferGeometryUtils.mergeBufferGeometries( translatedGeom );
+    const mergedGeom = mergeBufferGeometries( translatedGeom );
 
     const mesh = new Mesh( mergedGeom, this.getFontMaterial() );
 


### PR DESCRIPTION
Just fixed the import of `mergeBufferGeometries`.

```
 WARN  in ./node_modules/three-mesh-ui/src/content/MSDFText.js
"export 'BufferGeometryUtils' was not found in 'three/examples/jsm/utils/BufferGeometryUtils.js'
```

```
MSDFText.js?fe1f:75 Uncaught TypeError: Cannot read properties of undefined (reading 'mergeBufferGeometries')
    at Text.buildText (MSDFText.js?fe1f:75)
    at eval (VM5685 TextManager.js:68)
    at Text.createText (VM5685 TextManager.js:74)
    at Text.updateLayout (VM5683 Text.js:173)
    at Function.traverseUpdates (UpdateManager.js?40f5:132)
    at eval (UpdateManager.js?40f5:162)
    at Array.forEach (<anonymous>)
    at Function.traverseUpdates (UpdateManager.js?40f5:160)
    at eval (UpdateManager.js?40f5:92)
    at Array.forEach (<anonymous>)
```