### PR TITLE
Add borderOpacity and optional borderRadius array

### DIFF
--- a/examples/border.js
+++ b/examples/border.js
@@ -81,7 +81,7 @@ function makeTextPanel() {
 
 	panel.add(
 		new ThreeMeshUI.Text({
-			content: `Block.borderRadius\n\nBlock.borderWidth\n\nBlock.borderColor`,
+			content: `Block.borderRadius\n\nBlock.borderWidth\n\nBlock.borderColor\n\nBlock.borderOpacity`,
 		})
 	);
 
@@ -102,7 +102,8 @@ function loop() {
 	panel.set({
 		borderRadius: 0.2 + 0.2 * Math.sin( Date.now() / 500 ),
 		borderWidth: 0.05 - 0.06 * Math.sin( Date.now() / 500 ),
-		borderColor: new THREE.Color( 0.5 + 0.5 * Math.sin( Date.now() / 500 ), 0.5, 1 )
+		borderColor: new THREE.Color( 0.5 + 0.5 * Math.sin( Date.now() / 500 ), 0.5, 1 ),
+		borderOpacity: 1
 	});
 
 	// Don't forget, ThreeMeshUI must be updated manually.

--- a/examples/border.js
+++ b/examples/border.js
@@ -100,7 +100,7 @@ function onWindowResize() {
 function loop() {
 
 	panel.set({
-		borderRadius: 0.2 + 0.2 * Math.sin( Date.now() / 500 ),
+		borderRadius: [0, 0.2 + 0.2 * Math.sin( Date.now() / 500 ), 0, 0],
 		borderWidth: 0.05 - 0.06 * Math.sin( Date.now() / 500 ),
 		borderColor: new THREE.Color( 0.5 + 0.5 * Math.sin( Date.now() / 500 ), 0.5, 1 ),
 		borderOpacity: 1

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -60,6 +60,7 @@ export default function MaterialManager( Base = class {} ) {
                 borderRadius: this.getBorderRadius(),
                 borderWidth: this.getBorderWidth(),
                 borderColor: this.getBorderColor(),
+                borderOpacity: this.getBorderOpacity(),
                 size: this.size,
                 tSize: this.tSize
             }
@@ -83,6 +84,7 @@ export default function MaterialManager( Base = class {} ) {
                 this.backgroundUniforms.u_borderRadius.value = uniforms.borderRadius;
                 this.backgroundUniforms.u_borderWidth.value = uniforms.borderWidth;
                 this.backgroundUniforms.u_borderColor.value = uniforms.borderColor;
+                this.backgroundUniforms.u_borderOpacity.value = uniforms.borderOpacity;
 
             }
 
@@ -138,6 +140,7 @@ export default function MaterialManager( Base = class {} ) {
                 newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadius.value ||
                 newUniforms.borderWidth !== this.backgroundUniforms.u_borderWidth.value ||
                 newUniforms.borderColor !== this.backgroundUniforms.u_borderColor.value ||
+                newUniforms.borderOpacity !== this.backgroundUniforms.u_borderOpacity.value ||
                 newUniforms.size !== this.backgroundUniforms.u_size.value ||
                 newUniforms.tSize !== this.backgroundUniforms.u_tSize.value
             ) {
@@ -210,6 +213,7 @@ export default function MaterialManager( Base = class {} ) {
                 'u_borderRadius': { value: materialOptions.borderRadius },
                 'u_borderWidth': { value: materialOptions.borderWidth },
                 'u_borderColor': { value: materialOptions.borderColor },
+                'u_borderOpacity': { value: materialOptions.borderOpacity },
                 'u_size': { value: materialOptions.size },
                 'u_tSize': { value: materialOptions.tSize }
             };
@@ -309,6 +313,7 @@ const backgroundFragment = `
     uniform float u_borderRadius;
     uniform float u_borderWidth;
     uniform vec3 u_borderColor;
+    uniform float u_borderOpacity;
     uniform vec2 u_size;
     uniform vec2 u_tSize;
     uniform int u_backgroundMapping;
@@ -362,8 +367,11 @@ const backgroundFragment = `
 		vec4 textureSample = sampleTexture();
         float blendedOpacity = u_opacity * textureSample.a;
         vec3 blendedColor = textureSample.rgb * u_color;
-        if ( edgeDist * -1.0 < u_borderWidth ) blendedColor = u_borderColor;
+        if ( edgeDist * -1.0 < u_borderWidth ) {
+        gl_FragColor = vec4( blendedColor, u_borderOpacity );
+        } else {
 		gl_FragColor = vec4( blendedColor, blendedOpacity );
+		}
 		#include <clipping_planes_fragment>
 	}
 `;

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -71,7 +71,6 @@ export default function MaterialManager( Base = class {} ) {
         updateBackgroundMaterial() {
 
             if ( this.backgroundUniforms ) {
-
                 const uniforms = this.getBackgroundUniforms();
 
                 this.backgroundUniforms.u_texture.value = uniforms.texture;
@@ -81,7 +80,18 @@ export default function MaterialManager( Base = class {} ) {
                 this.backgroundUniforms.u_size.value = uniforms.size;
                 this.backgroundUniforms.u_tSize.value = uniforms.tSize;
 
-                this.backgroundUniforms.u_borderRadius.value = uniforms.borderRadius;
+                if (Array.isArray(uniforms.borderRadius)) {
+                    this.backgroundUniforms.u_borderRadiusTopLeft.value = uniforms.borderRadius[0];
+                    this.backgroundUniforms.u_borderRadiusTopRight.value = uniforms.borderRadius[1];
+                    this.backgroundUniforms.u_borderRadiusBottomRight.value = uniforms.borderRadius[2];
+                    this.backgroundUniforms.u_borderRadiusBottomLeft.value = uniforms.borderRadius[3];
+                } else {
+                    this.backgroundUniforms.u_borderRadiusTopLeft.value = uniforms.borderRadius;
+                    this.backgroundUniforms.u_borderRadiusTopRight.value = uniforms.borderRadius;
+                    this.backgroundUniforms.u_borderRadiusBottomRight.value = uniforms.borderRadius;
+                    this.backgroundUniforms.u_borderRadiusBottomLeft.value = uniforms.borderRadius;
+                }
+
                 this.backgroundUniforms.u_borderWidth.value = uniforms.borderWidth;
                 this.backgroundUniforms.u_borderColor.value = uniforms.borderColor;
                 this.backgroundUniforms.u_borderOpacity.value = uniforms.borderOpacity;
@@ -132,17 +142,38 @@ export default function MaterialManager( Base = class {} ) {
 
                 this.backgroundMaterial = this._makeBackgroundMaterial( newUniforms );
 
-            } else if (
-                newUniforms.texture !== this.backgroundUniforms.u_texture.value ||
-                newUniforms.color !== this.backgroundUniforms.u_color.value ||
-                newUniforms.opacity !== this.backgroundUniforms.u_opacity.value ||
-                newUniforms.backgroundMapping !== this.backgroundUniforms.u_backgroundMapping.value ||
-                newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadius.value ||
-                newUniforms.borderWidth !== this.backgroundUniforms.u_borderWidth.value ||
-                newUniforms.borderColor !== this.backgroundUniforms.u_borderColor.value ||
-                newUniforms.borderOpacity !== this.backgroundUniforms.u_borderOpacity.value ||
-                newUniforms.size !== this.backgroundUniforms.u_size.value ||
-                newUniforms.tSize !== this.backgroundUniforms.u_tSize.value
+                return this.backgroundMaterial
+
+            }
+
+            let borderRadiusChanged;
+            if (Array.isArray(newUniforms.borderRadius)) {
+                borderRadiusChanged = (
+                  newUniforms.borderRadius[0] !== this.backgroundUniforms.u_borderRadiusTopLeft.value ||
+                  newUniforms.borderRadius[1] !== this.backgroundUniforms.u_borderRadiusTopRight.value ||
+                  newUniforms.borderRadius[2] !== this.backgroundUniforms.u_borderRadiusBottomRight.value ||
+                  newUniforms.borderRadius[3] !== this.backgroundUniforms.u_borderRadiusBottomLeft.value
+                )
+            } else {
+                borderRadiusChanged = (
+                  newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadiusTopLeft.value ||
+                  newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadiusTopRight.value ||
+                  newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadiusBottomRight.value ||
+                  newUniforms.borderRadius !== this.backgroundUniforms.u_borderRadiusBottomLeft.value
+                )
+            }
+
+            if (
+              newUniforms.texture !== this.backgroundUniforms.u_texture.value ||
+              newUniforms.color !== this.backgroundUniforms.u_color.value ||
+              newUniforms.opacity !== this.backgroundUniforms.u_opacity.value ||
+              newUniforms.backgroundMapping !== this.backgroundUniforms.u_backgroundMapping.value ||
+              borderRadiusChanged ||
+              newUniforms.borderWidth !== this.backgroundUniforms.u_borderWidth.value ||
+              newUniforms.borderColor !== this.backgroundUniforms.u_borderColor.value ||
+              newUniforms.borderOpacity !== this.backgroundUniforms.u_borderOpacity.value ||
+              newUniforms.size !== this.backgroundUniforms.u_size.value ||
+              newUniforms.tSize !== this.backgroundUniforms.u_tSize.value
             ) {
 
                 this.updateBackgroundMaterial();
@@ -210,13 +241,28 @@ export default function MaterialManager( Base = class {} ) {
                 'u_color': { value: materialOptions.color },
                 'u_opacity': { value: materialOptions.opacity },
                 'u_backgroundMapping': { value: materialOptions.backgroundMapping },
-                'u_borderRadius': { value: materialOptions.borderRadius },
                 'u_borderWidth': { value: materialOptions.borderWidth },
                 'u_borderColor': { value: materialOptions.borderColor },
+                'u_borderRadiusTopLeft': { value: 0 },
+                'u_borderRadiusTopRight': { value: 0 },
+                'u_borderRadiusBottomRight': { value: 0 },
+                'u_borderRadiusBottomLeft': { value: 0 },
                 'u_borderOpacity': { value: materialOptions.borderOpacity },
                 'u_size': { value: materialOptions.size },
                 'u_tSize': { value: materialOptions.tSize }
             };
+
+            if (Array.isArray(materialOptions.borderRadius)) {
+                this.backgroundUniforms['u_borderRadiusTopLeft'].values = materialOptions.borderRadius[0];
+                this.backgroundUniforms['u_borderRadiusTopRight'].values = materialOptions.borderRadius[1];
+                this.backgroundUniforms['u_borderRadiusBottomRight'].values = materialOptions.borderRadius[2];
+                this.backgroundUniforms['u_borderRadiusBottomLeft'].values = materialOptions.borderRadius[3];
+            } else {
+                this.backgroundUniforms['u_borderRadiusTopLeft'].values = materialOptions.borderRadius;
+                this.backgroundUniforms['u_borderRadiusTopRight'].values = materialOptions.borderRadius;
+                this.backgroundUniforms['u_borderRadiusBottomRight'].values = materialOptions.borderRadius;
+                this.backgroundUniforms['u_borderRadiusBottomLeft'].values = materialOptions.borderRadius;
+            }
 
             return new ShaderMaterial({
                 uniforms: this.backgroundUniforms,
@@ -310,7 +356,10 @@ const backgroundFragment = `
 	uniform vec3 u_color;
 	uniform float u_opacity;
 
-    uniform float u_borderRadius;
+    uniform float u_borderRadiusTopLeft;
+    uniform float u_borderRadiusTopRight;
+    uniform float u_borderRadiusBottomLeft;
+    uniform float u_borderRadiusBottomRight;
     uniform float u_borderWidth;
     uniform vec3 u_borderColor;
     uniform float u_borderOpacity;
@@ -328,9 +377,26 @@ const backgroundFragment = `
         vec2 corner = u_size * 0.5;
         vec2 offsetCorner = corner - abs( planeSpaceCoord );
         float innerRadDist = min( offsetCorner.x, offsetCorner.y ) * -1.0;
-        float roundedDist = length( max( abs( planeSpaceCoord ) - u_size * 0.5 + u_borderRadius, 0.0 ) ) - u_borderRadius;
-        float s = step( innerRadDist * -1.0, u_borderRadius );
-        return mix( innerRadDist, roundedDist, s );
+        if (vUv.x < 0.5 && vUv.y >= 0.5) {
+            float roundedDist = length( max( abs( planeSpaceCoord ) - u_size * 0.5 + u_borderRadiusTopLeft, 0.0 ) ) - u_borderRadiusTopLeft;
+            float s = step( innerRadDist * -1.0, u_borderRadiusTopLeft );
+            return mix( innerRadDist, roundedDist, s );
+        }
+        if (vUv.x >= 0.5 && vUv.y >= 0.5) {
+            float roundedDist = length( max( abs( planeSpaceCoord ) - u_size * 0.5 + u_borderRadiusTopRight, 0.0 ) ) - u_borderRadiusTopRight;
+            float s = step( innerRadDist * -1.0, u_borderRadiusTopRight );
+            return mix( innerRadDist, roundedDist, s );
+        }
+        if (vUv.x >= 0.5 && vUv.y < 0.5) {
+            float roundedDist = length( max( abs( planeSpaceCoord ) - u_size * 0.5 + u_borderRadiusBottomRight, 0.0 ) ) - u_borderRadiusBottomRight;
+            float s = step( innerRadDist * -1.0, u_borderRadiusBottomRight );
+            return mix( innerRadDist, roundedDist, s );
+        }
+        if (vUv.x < 0.5 && vUv.y < 0.5) {
+            float roundedDist = length( max( abs( planeSpaceCoord ) - u_size * 0.5 + u_borderRadiusBottomLeft, 0.0 ) ) - u_borderRadiusBottomLeft;
+            float s = step( innerRadDist * -1.0, u_borderRadiusBottomLeft );
+            return mix( innerRadDist, roundedDist, s );
+        }
     }
 
     vec4 sampleTexture() {

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -96,11 +96,11 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this.parent
 
-            } 
+            }
 
             return null
 
-            
+
 
         }
 
@@ -111,11 +111,11 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this
 
-            } 
+            }
 
             return this.parent.getHighestParent();
 
-            
+
 
         }
 
@@ -133,7 +133,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this[ propName ]
 
-            } 
+            }
 
             return DEFAULTS[ propName ]
 
@@ -183,6 +183,10 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'borderColor' );
         }
 
+        getBorderOpacity() {
+            return this._getProperty( 'borderOpacity' );
+        }
+
         /// SPECIALS
 
         /** return the first parent with a 'threeOBJ' property */
@@ -196,11 +200,11 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this
 
-            } 
+            }
 
             return DEFAULTS.container
 
-            
+
 
         }
 
@@ -213,7 +217,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this.parent.getParentsNumber( i + 1 )
 
-            } 
+            }
 
             return i
 
@@ -322,7 +326,7 @@ export default function MeshUIComponent( Base = class {} ) {
         _updateFontFamily( font ) {
 
             this.fontFamily = font;
-            
+
             this.traverse( (child)=> {
 
                 if ( child.isUI ) child.update( true, true, false );
@@ -405,6 +409,7 @@ export default function MeshUIComponent( Base = class {} ) {
                 case "borderRadius" :
                 case "borderWidth" :
                 case "borderColor" :
+                case "borderOpacity" :
                     innerNeedsUpdate = true;
                     this[ prop ] = options[ prop ];
                     break;
@@ -428,7 +433,7 @@ export default function MeshUIComponent( Base = class {} ) {
                 FontLibrary.setFontTexture( this, options.fontTexture );
                 layoutNeedsUpdate = false;
             }
-            
+
             // Call component update
 
             this.update( parsingNeedsUpdate, layoutNeedsUpdate, innerNeedsUpdate );
@@ -455,7 +460,7 @@ export default function MeshUIComponent( Base = class {} ) {
         setState( state ) {
 
             const savedState = this.states[ state ];
-            
+
             if ( !savedState ) {
                 console.warn(`state "${ state }" does not exist within this component`);
                 return


### PR DESCRIPTION
Adds `borderOpacity` to `Block` allowing users to specify a different opacity on the border – defaults to the `backgroundOpacity`.

Also adds an optional array to `borderRadius` allowing users to specify a different radius for each corner (top-left, top-right, bottom-right, bottom-left).

![Screenshot 2021-12-17 at 09 11 14](https://user-images.githubusercontent.com/5284715/146520235-96df9500-6259-4fcb-aff8-46affe8ed28c.png)

Closes #91 