### PR TITLE
LetterSpacing

### DIFF
--- a/config/webpack.prodConfig.js
+++ b/config/webpack.prodConfig.js
@@ -17,6 +17,7 @@ let pages = [
 	['onafterupdate', 'onAfterUpdate'],
 	['manual_positioning', 'manual content positioning'],
 	['keyboard', 'keyboard'],
+	['letter_spacing', 'letter spacing'],
 ];
 
 // create one config for each of the data set above
@@ -71,7 +72,8 @@ module.exports = env => {
 			hidden_overflow: './examples/hidden_overflow.js',
 			onafterupdate: './examples/onafterupdate.js',
 			manual_positioning: './examples/manual_positioning.js',
-			keyboard: './examples/keyboard.js'
+			keyboard: './examples/keyboard.js',
+			letter_spacing: './examples/letter_spacing.js'
 		},
 
 		plugins: pagesConfig,

--- a/examples/letter_spacing.js
+++ b/examples/letter_spacing.js
@@ -1,0 +1,137 @@
+
+import * as THREE from 'three';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BoxLineGeometry } from 'three/examples/jsm/geometries/BoxLineGeometry.js';
+
+import ThreeMeshUI from '../src/three-mesh-ui.js';
+
+import FontJSON from './assets/Roboto-msdf.json';
+import FontImage from './assets/Roboto-msdf.png';
+
+const WIDTH = window.innerWidth;
+const HEIGHT = window.innerHeight;
+
+let scene, camera, renderer, controls ;
+
+window.addEventListener('load', init );
+window.addEventListener('resize', onWindowResize );
+
+//
+
+function init() {
+
+	scene = new THREE.Scene();
+	scene.background = new THREE.Color( 0x505050 );
+
+	camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 100 );
+
+	renderer = new THREE.WebGLRenderer({
+		antialias: true
+	});
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( WIDTH, HEIGHT );
+	renderer.xr.enabled = true;
+	document.body.appendChild(VRButton.createButton(renderer));
+	document.body.appendChild( renderer.domElement );
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	camera.position.set( 0, 1.6, 0 );
+	controls.target = new THREE.Vector3( 0, 1, -1.8 );
+	controls.update();
+
+	// ROOM
+
+	const room = new THREE.LineSegments(
+		new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ).translate( 0, 3, 0 ),
+		new THREE.LineBasicMaterial( { color: 0x808080 } )
+	);
+
+	scene.add( room );
+
+	// TEXT PANEL
+
+	makeTextPanel();
+
+	//
+
+	renderer.setAnimationLoop( loop );
+
+};
+
+//
+
+function makeTextPanel() {
+
+	const container = new ThreeMeshUI.Block({
+		width: 1.2,
+		height: 0.5,
+		padding: 0.05,
+		justifyContent: 'center',
+		alignContent: 'left',
+		fontFamily: FontJSON,
+		fontTexture: FontImage
+	});
+
+	container.position.set( 0, 1, -1.8 );
+	container.rotation.x = -0.55;
+	scene.add( container );
+
+	//
+
+	const text = new ThreeMeshUI.Text({
+			content: "This library supports line-break-friendly-characters, and letter spacing,",
+			fontSize: 0.055
+		});
+
+	container.add(
+
+		text,
+
+		new ThreeMeshUI.Text({
+			content: " As well as multi-font-size lines with consistent vertical spacing.",
+			fontSize: 0.08
+		})
+
+	);
+
+	// Update the letterSpacing in time in order demo its effect
+	let letterSpacingSpeed = 0.1;
+
+	setInterval( ()=>{
+
+		let letterSpacing = text.getLetterSpacing();
+		letterSpacing += letterSpacingSpeed;
+
+		// reverse the speed at some points
+		if( letterSpacing > 1 || letterSpacing <= 0 ){
+			letterSpacingSpeed *= -1;
+		}
+
+		// update the text component
+		text.set({letterSpacing:letterSpacing});
+
+	},2000);
+
+};
+
+// handles resizing the renderer when the viewport is resized
+
+function onWindowResize() {
+	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.updateProjectionMatrix();
+	renderer.setSize( window.innerWidth, window.innerHeight );
+};
+
+//
+
+function loop() {
+
+	// Don't forget, ThreeMeshUI must be updated manually.
+	// This has been introduced in version 3.0.0 in order
+	// to improve performance
+	ThreeMeshUI.update();
+
+	controls.update();
+	renderer.render( scene, camera );
+};

--- a/examples/letter_spacing.js
+++ b/examples/letter_spacing.js
@@ -76,22 +76,16 @@ function makeTextPanel() {
 	container.position.set( 0, 1, -1.8 );
 	container.rotation.x = -0.55;
 	scene.add( container );
-
 	//
 
 	const text = new ThreeMeshUI.Text({
-			content: "This library supports line-break-friendly-characters, and letter spacing,",
+			content: "letterSpacing ".repeat(3),
 			fontSize: 0.055
 		});
 
 	container.add(
 
 		text,
-
-		new ThreeMeshUI.Text({
-			content: " As well as multi-font-size lines with consistent vertical spacing.",
-			fontSize: 0.08
-		})
 
 	);
 
@@ -109,7 +103,7 @@ function makeTextPanel() {
 		}
 
 		// update the text component
-		text.set({letterSpacing:letterSpacing});
+		text.set({letterSpacing});
 
 	},2000);
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -56,6 +56,7 @@ export default class Text extends mix.withBase( Object3D )(
         const fontSize = this.getFontSize();
         const breakChars = this.getBreakOn();
         const textType = this.getTextType();
+        const letterSpacing = this.getLetterSpacing()* fontSize;
 
         // Abort condition
         
@@ -104,7 +105,8 @@ export default class Text extends mix.withBase( Object3D )(
                 anchor: dimensions.anchor,
                 lineBreak,
                 glyph,
-                fontSize
+                fontSize,
+                letterSpacing: letterSpacing
             };
 
         });

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -56,7 +56,6 @@ export default class Text extends mix.withBase( Object3D )(
         const fontSize = this.getFontSize();
         const breakChars = this.getBreakOn();
         const textType = this.getTextType();
-        const letterSpacing = this.getLetterSpacing()* fontSize;
 
         // Abort condition
         
@@ -105,8 +104,7 @@ export default class Text extends mix.withBase( Object3D )(
                 anchor: dimensions.anchor,
                 lineBreak,
                 glyph,
-                fontSize,
-                letterSpacing: letterSpacing
+                fontSize
             };
 
         });

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -58,7 +58,7 @@ export default function InlineManager( Base = class {} ) {
 
                             inline.offsetX = 0;
 
-                            return inline.width;
+                            return inline.width+ inline.letterSpacing;
 
                         } 
 
@@ -72,7 +72,7 @@ export default function InlineManager( Base = class {} ) {
 
                         //
 
-                        return lastInlineOffset + inline.width;
+                        return lastInlineOffset + inline.width + inline.letterSpacing;
 
                     }, lastInlineOffset );
 
@@ -215,7 +215,7 @@ export default function InlineManager( Base = class {} ) {
             return this.distanceToNextBreak(
                 inlines,
                 currentIdx + 1,
-                accu + inlines[ currentIdx ].width
+                accu + inlines[ currentIdx ].width + inlines[currentIdx].letterSpacing
             );
 
             

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -42,11 +42,13 @@ export default function InlineManager( Base = class {} ) {
                     // Compute offset of each children according to its dimensions
                     //////////////////////////////////////////////////////////////
 
+                    const letterSpacing = inlineComponent.isText ? inlineComponent.getLetterSpacing() * inlineComponent.getFontSize() : 0;
+
                     const currentInlineInfo = inlineComponent.inlines.reduce( (lastInlineOffset, inline, i, inlines)=> {
 
                         // Line break
 
-                        const nextBreak = this.distanceToNextBreak( inlines, i );
+                        const nextBreak = this.distanceToNextBreak( inlines, i , letterSpacing );
 
                         if (
                             lastInlineOffset + inline.width > INNER_WIDTH ||
@@ -58,7 +60,7 @@ export default function InlineManager( Base = class {} ) {
 
                             inline.offsetX = 0;
 
-                            return inline.width+ inline.letterSpacing;
+                            return inline.width + letterSpacing;
 
                         } 
 
@@ -72,7 +74,7 @@ export default function InlineManager( Base = class {} ) {
 
                         //
 
-                        return lastInlineOffset + inline.width + inline.letterSpacing;
+                        return lastInlineOffset + inline.width + letterSpacing;
 
                     }, lastInlineOffset );
 
@@ -197,7 +199,7 @@ export default function InlineManager( Base = class {} ) {
          * as break-line-safe ( like whitespace for instance )
          * @private
          */
-        distanceToNextBreak( inlines, currentIdx, accu ) {
+        distanceToNextBreak( inlines, currentIdx, letterSpacing , accu ) {
 
             accu = accu || 0 ;
 
@@ -215,6 +217,7 @@ export default function InlineManager( Base = class {} ) {
             return this.distanceToNextBreak(
                 inlines,
                 currentIdx + 1,
+                letterSpacing,
                 accu + inlines[ currentIdx ].width + inlines[currentIdx].letterSpacing
             );
 

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -266,6 +266,10 @@ export default function MeshUIComponent( Base = class {} ) {
             return (this.hiddenOverflow === undefined) ? DEFAULTS.hiddenOverflow : this.hiddenOverflow;
         }
 
+        getLetterSpacing() {
+          return (this.letterSpacing === undefined) ? DEFAULTS.letterSpacing : this.letterSpacing;
+        }
+
         ///////////////
         ///  UPDATE
         ///////////////
@@ -370,6 +374,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 case "content" :
                 case "fontSize" :
+                case "letterSpacing" :
                     if ( this.isText ) parsingNeedsUpdate = true;
                     layoutNeedsUpdate = true;
                     this[ prop ] = options[ prop ];

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -147,6 +147,10 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'fontSize' );
         }
 
+        getLetterSpacing() {
+          return this._getProperty( 'letterSpacing' );
+        }
+
         getFontTexture() {
             return this._getProperty( 'fontTexture' );
         }
@@ -266,10 +270,6 @@ export default function MeshUIComponent( Base = class {} ) {
             return (this.hiddenOverflow === undefined) ? DEFAULTS.hiddenOverflow : this.hiddenOverflow;
         }
 
-        getLetterSpacing() {
-          return (this.letterSpacing === undefined) ? DEFAULTS.letterSpacing : this.letterSpacing;
-        }
-
         ///////////////
         ///  UPDATE
         ///////////////
@@ -374,7 +374,6 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 case "content" :
                 case "fontSize" :
-                case "letterSpacing" :
                     if ( this.isText ) parsingNeedsUpdate = true;
                     layoutNeedsUpdate = true;
                     this[ prop ] = options[ prop ];
@@ -388,7 +387,7 @@ export default function MeshUIComponent( Base = class {} ) {
                     this[ prop ] = options[ prop ];
                     break;
 
-                case "fontSize" :
+                case "letterSpacing" :
                 case "interLine" :
                 case "margin" :
                 case "contentDirection" :

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -27,6 +27,7 @@ export default {
 	backgroundOpaqueOpacity: 1.0,
 	backgroundTexture: DefaultBackgroundTexture(),
 	hiddenOverflow: false,
+	letterSpacing:0
 };
 
 //


### PR DESCRIPTION
This contains the implementation of LetterSpacing #98  and a example.
Im not sure the example worth to stay there, but at least you can use it as a line-break validator.

I choose to put computed `letterSpacing` value as [Text inlines.element](https://github.com/swingingtom/three-mesh-ui/blob/acfe9a07bb267b94a2304c0b4d4720aafb9a888c/src/components/Text.js#L102) property because the letterSpacing value was also required in [InlineManager.distanceToNextBreak](https://github.com/swingingtom/three-mesh-ui/blob/acfe9a07bb267b94a2304c0b4d4720aafb9a888c/src/components/core/InlineManager.js#L200). Which only had `Text.inlines` as available parameters right now. 
It waste a bit of memory because every `Text.inlines.element` of a same `Text` has now the same value behind `letterSpacing` property. But I did not want to start nor to propose a refactoring of `InlineManager.distanceToNextBreak`

This is why updating the `letterSpacing` property might also require a [parsingNeedsUpdate](https://github.com/swingingtom/three-mesh-ui/blob/acfe9a07bb267b94a2304c0b4d4720aafb9a888c/src/components/core/MeshUIComponent.js#L375)

