### PR TITLE
Fix letter spacing next line break

### DIFF
--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -218,7 +218,7 @@ export default function InlineManager( Base = class {} ) {
                 inlines,
                 currentIdx + 1,
                 letterSpacing,
-                accu + inlines[ currentIdx ].width + inlines[currentIdx].letterSpacing
+                accu + inlines[ currentIdx ].width + letterSpacing
             );
 
             


### PR DESCRIPTION
There was the artefact that was causing that. 
I replayed all examples, everything seems up again.
