### PR TITLE
Prevent first line letter to add whitespaces

### DIFF
--- a/examples/nested_blocks.js
+++ b/examples/nested_blocks.js
@@ -162,6 +162,57 @@ function makeTextPanel() {
 
   rightSubBlock.add(subSubBlock1, subSubBlock2);
 
+
+  // @TODO : TO BE REMOVED BEFORE PUBLISHING -------------------------------------------------
+  // -----------------------------------------------------------------------------------------
+    const rightSubBlock1 = new ThreeMeshUI.Block({
+        margin: 0.025,
+    });
+
+    const subSubBlock11 = new ThreeMeshUI.Block({
+        height: 0.35,
+        width: 0.5,
+        margin: 0.025,
+        padding: 0.02,
+        fontSize: 0.04,
+        justifyContent: "center",
+        backgroundOpacity: 0,
+    }).add(
+        new ThreeMeshUI.Text({
+            content: "Known for its extremely keeled dorsal scales that give it a ",
+        }),
+
+        new ThreeMeshUI.Text({
+            content: "bristly",
+            fontColor: new THREE.Color(0x92e66c),
+        }),
+
+        new ThreeMeshUI.Text({
+            content: " appearance.",
+        })
+    );
+
+    const subSubBlock21 = new ThreeMeshUI.Block({
+        height: 0.53,
+        width: 0.5,
+        margin: 0.01,
+        padding: 0.02,
+        fontSize: 0.025,
+        alignContent: "left",
+        backgroundOpacity: 0,
+    }).add(
+        new ThreeMeshUI.Text({
+            content:
+                "The males of this species grow to maximum total length of 73 cm (29 in):                    body 58 cm (23 in), tail 15 cm (5.9 in). Females grow to a maximum total length of 58 cm (23 in). The males are surprisingly long and slender compared to the females.\nThe head has a short snout, more so in males than in females.\nThe eyes are large and surrounded by 9–16 circumorbital scales. The orbits (eyes) are separated by 7–9 scales.",
+        })
+    );
+
+    rightSubBlock1.add(subSubBlock11, subSubBlock21);
+
+    // -----------------------------------------------------------------------------------
+    // -------------------------------------------------  TO BE REMOVED BEFORE PUBLISHING
+
+
   //
 
   const contentContainer = new ThreeMeshUI.Block({
@@ -171,7 +222,7 @@ function makeTextPanel() {
     backgroundOpacity: 0,
   });
 
-  contentContainer.add(leftSubBlock, rightSubBlock);
+  contentContainer.add(leftSubBlock, rightSubBlock, rightSubBlock1);
   container.add(contentContainer);
 
   //

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -66,24 +66,22 @@ export default function InlineManager( Base = class {} ) {
 
                             inline.offsetX = xoffset;
 
-                            // Workaround : Sometimes, ThreeMeshUI linebreaks before a newline "\n"
-                            //              and `lines.push([ inline ])` push the newline char "\n" itself as first char
-                            //
-                            // LetterSpacing feature was introducing a visual glitch
-                            // by adding constant letterSpacing to those hidden chars
-                            //
-                            // So as workaround if the first char has a width of 0, do not add letterSpacing
-                            if( inline.width > 0 ){
 
-                                // Do not kern first letter of a line, its has not lefthanded peer char
-                                // But still use the letterspacing
-                                return xadvance + xoffset + letterSpacing;
+                            // if the first inline of this new line :
+                            //   has a width of zero ( such as "\n" glyph )
+                            //   or
+                            //   is a space
+                            // @TODO: This might be more widely supported "\r \t"
+                            if( inline.width === 0 || inline.glyph === " " ){
+
+                                // restart the lastInlineOffset as zero.
+                                return 0;
                             }else{
 
-                                // When line breaker here "\n" its width is 0
-                                // Fix by setting width of 0
-                                // as letterSpacing was still adding constant offset on empty char
-                                return 0;
+                                // compute lastInlineOffset normally
+                                // except for kerning which won't apply
+                                // as there is visually no lefthanded glyph to kern with
+                                return xadvance + xoffset + letterSpacing;
                             }
 
                         }
@@ -91,7 +89,7 @@ export default function InlineManager( Base = class {} ) {
                         lines[ lines.length - 1 ].push( inline );
 
                         inline.offsetX = lastInlineOffset + xoffset + kerning;
-                    
+
                         const result = lastInlineOffset + xadvance + kerning + letterSpacing;
 
                         return result;
@@ -245,7 +243,7 @@ export default function InlineManager( Base = class {} ) {
                 return accu + xadvance
 
             // no line break is possible on this character
-            } 
+            }
 
             return this.distanceToNextBreak(
                 inlines,
@@ -254,7 +252,7 @@ export default function InlineManager( Base = class {} ) {
                 accu + xadvance + letterSpacing + xoffset + kerning
             );
 
-            
+
 
         }
 
@@ -277,7 +275,7 @@ export default function InlineManager( Base = class {} ) {
             // Previous glyph was break-line-friendly
             return BREAK_ON.indexOf( prevChar.glyph ) > -1
 
-        }			 
+        }
 
 	}
 


### PR DESCRIPTION
This would fix #109 

It collapse a space character only if it was the linebreaker. 

But this doesn't act as trim. 
![tmu-notrim](https://user-images.githubusercontent.com/17314210/148677318-51434e87-aee0-4ad7-8dee-2021e557338c.png)
Other space characters than the linebreaker are kept.
