### PR TITLE
improve text antialiasing

### DIFF
--- a/config/webpack.prodConfig.js
+++ b/config/webpack.prodConfig.js
@@ -19,6 +19,7 @@ let pages = [
 	['keyboard', 'keyboard'],
 	['letter_spacing', 'letter spacing'],
 	['font_kerning', 'font kerning'],
+	['antialiasing', 'antialiasing'],
 ];
 
 // create one config for each of the data set above
@@ -76,6 +77,7 @@ module.exports = env => {
 			keyboard: './examples/keyboard.js',
 			letter_spacing: './examples/letter_spacing.js',
 			font_kerning: './examples/font_kerning.js',
+			antialiasing: './examples/antialiasing.js',
 		},
 
 		plugins: pagesConfig,

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -1,0 +1,147 @@
+
+import * as THREE from 'three';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BoxLineGeometry } from 'three/examples/jsm/geometries/BoxLineGeometry.js';
+
+import ThreeMeshUI from '../src/three-mesh-ui.js';
+
+import FontJSON from './assets/Roboto-msdf.json';
+import FontImage from './assets/Roboto-msdf.png';
+
+const WIDTH = window.innerWidth;
+const HEIGHT = window.innerHeight;
+
+let scene, camera, renderer, controls ;
+
+const textContent = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-:?!
+The males of this species grow to maximum total length of 73 cm (29 in): body 58 cm (23 in), tail 15 cm (5.9 in). Females grow to a maximum total length of 58 cm (23 in). The males are surprisingly long and slender compared to the females.\nThe head has a short snout, more so in males than in females.\nThe eyes are large and surrounded by 9–16 circumorbital scales. The orbits (eyes) are separated by 7–9 scales.`;
+
+window.addEventListener('load', init );
+window.addEventListener('resize', onWindowResize );
+
+//
+
+function init() {
+
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color( 0x000000 );
+
+  camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 500 );
+
+  renderer = new THREE.WebGLRenderer({
+    antialias: true
+  });
+  renderer.setPixelRatio( window.devicePixelRatio );
+  renderer.setSize( WIDTH, HEIGHT );
+  renderer.xr.enabled = true;
+  document.body.appendChild(VRButton.createButton(renderer));
+  document.body.appendChild( renderer.domElement );
+
+  controls = new OrbitControls( camera, renderer.domElement );
+  camera.position.set( 0, 1.0, 1.0 );
+  controls.target = new THREE.Vector3( 0, 1, 0 );
+  controls.update();
+
+  // ROOM
+
+  const room = new THREE.LineSegments(
+    new BoxLineGeometry( 20, 20, 20, 10, 10, 10 ).translate( 0, 3, 0 ),
+    new THREE.LineBasicMaterial( { color: 0x808080 } )
+  );
+
+  // scene.add( room );
+
+  // TEXT PANEL
+
+  // attempt to have a pixel-perfect match to the reference MSDF implementation
+  
+  makeTextPanel(0.024,.1,-2,0,0,0,true);
+  makeTextPanel(2.024,.1,-2,0,0,0,false);
+
+  makeTextPanel(0,0,-3,0,0,0);
+  makeTextPanel(0,0,-5,0,0,0);
+  makeTextPanel(0,0,-7,0,0,0);
+  makeTextPanel(0,0,-9,0,0,0);
+  
+  makeTextPanel(-1.5,0.5,-4,0,0.9,0);
+  makeTextPanel(-1.5,1.1,-4,0,1.3,0);
+  makeTextPanel(-1.5,1.7,-4,0,1.6,0);
+  makeTextPanel(-2.5,0.5,-4,0,0.9,0, true);
+  makeTextPanel(-2.5,1.1,-4,0,1.3,0, true);
+  makeTextPanel(-2.5,1.7,-4,0,1.6,0, true);
+
+
+  makeTextPanel(2.0,0,-3,-1,0,0);
+  makeTextPanel(2.0,0,-5,-1,0,0);
+  makeTextPanel(2.4,0.1,-7,-1,0,0);
+  
+  makeTextPanel(1.5,1,-8,-0.55,-0.9,0);
+  makeTextPanel(0,1.2,-8,-0.55,0,-0.9);
+  makeTextPanel(0,1.75,-5,-0.55,0,-0.9);
+  makeTextPanel(0,2.0,-3,-0.55,0,-0.9);
+
+  //
+
+  renderer.setAnimationLoop( loop );
+
+};
+
+//
+
+function makeTextPanel(x,y,z,rotX, rotY, rotZ, supersample) {
+
+  const container = new ThreeMeshUI.Block({
+    width: 2.0,
+    height: 0.6,
+    padding: 0.05,
+    justifyContent: 'center',
+    alignContent: 'left',
+    fontFamily: FontJSON,
+    fontTexture: FontImage,
+    fontColor: new THREE.Color( 0xffffff ),
+    backgroundOpacity: 1,
+    backgroundColor: new THREE.Color( 0x000000 ),
+    fontSupersampling: supersample,
+  });
+
+  scene.add( container );
+  container.position.set(x,y,z);
+  container.rotation.set(rotX, rotY, rotZ);
+
+  container.add(
+    new ThreeMeshUI.Text({
+      content: textContent,
+      fontKerning: "normal",
+      fontSize: 0.045,
+    }),
+  );
+
+  return container;
+};
+
+// handles resizing the renderer when the viewport is resized
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize( window.innerWidth, window.innerHeight );
+};
+
+//
+var clock = new THREE.Clock(true);
+clock.start();
+
+function loop() {
+
+  // Don't forget, ThreeMeshUI must be updated manually.
+  // This has been introduced in version 3.0.0 in order
+  // to improve performance
+  ThreeMeshUI.update();
+
+  // swinging motion to see motion aliasing better
+  let time = clock.getElapsedTime();
+  controls.target.set(Math.sin(time * 21) * 0.0031, 1 + Math.sin(time * 23) * 0.0023, -1.8 );
+  controls.update();
+  renderer.render( scene, camera );
+};

--- a/src/components/core/FontLibrary.js
+++ b/src/components/core/FontLibrary.js
@@ -15,8 +15,7 @@ loading it twice, even if the two component are not in the same parent/child hie
 
 */
 
-import { FileLoader } from 'three';
-import { TextureLoader } from 'three';
+import { FileLoader, TextureLoader, LinearFilter } from 'three';
 
 const fileLoader = new FileLoader();
 const requiredFontFamilies = [];
@@ -72,6 +71,10 @@ function setFontTexture( component, url ) {
 		requiredFontTextures.push( url );
 
 		textureLoader.load( url, ( texture )=> {
+
+			texture.generateMipmaps = false;
+			texture.minFilter = LinearFilter;
+			texture.magFilter = LinearFilter;
 
 			fontTextures[ url ] = texture;
 
@@ -208,6 +211,11 @@ font with specified name will be overwritten, but components using it won't be u
 
 */
 function addFont(name, json, texture) {
+
+	texture.generateMipmaps = false;
+	texture.minFilter = LinearFilter;
+	texture.magFilter = LinearFilter;
+
 	requiredFontFamilies.push( name );
 	fontFamilies[ name ] = json;
 

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -190,7 +190,8 @@ export default function MaterialManager( Base = class {} ) {
             const newUniforms = {
                 'u_texture': this.getFontTexture(),
                 'u_color': this.getFontColor(),
-                'u_opacity': this.getFontOpacity()
+                'u_opacity': this.getFontOpacity(),
+                'u_pxRange': this.getPXRange()
             };
 
             if ( !this.fontMaterial || !this.textUniforms ) {
@@ -217,7 +218,8 @@ export default function MaterialManager( Base = class {} ) {
             this.textUniforms = {
                 'u_texture': { value: materialOptions.u_texture },
                 'u_color': { value: materialOptions.u_color },
-                'u_opacity': { value: materialOptions.u_opacity }
+                'u_opacity': { value: materialOptions.u_opacity },
+                'u_pxRange': { value: materialOptions.u_pxRange }
             }
 
             return new ShaderMaterial({
@@ -308,6 +310,7 @@ const textFragment = `
 	uniform sampler2D u_texture;
 	uniform vec3 u_color;
 	uniform float u_opacity;
+    uniform float u_pxRange;
 
 	varying vec2 vUv;
 
@@ -321,9 +324,7 @@ const textFragment = `
 	}
 
     float screenPxRange() {
-        float pxRange = 4.0; // not sure what this variable is about...
-
-        vec2 unitRange = vec2(pxRange)/vec2(textureSize(u_texture, 0));
+        vec2 unitRange = vec2(u_pxRange)/vec2(textureSize(u_texture, 0));
         vec2 screenTexSize = vec2(1.0)/fwidth(vUv);
         return max(0.5*dot(unitRange, screenTexSize), 1.0);
     }

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -129,7 +129,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 return this.parent._getProperty( propName )
 
-            } else if ( this[ propName ] ) {
+            } else if ( this[ propName ] !== undefined ) {
 
                 return this[ propName ]
 
@@ -188,8 +188,8 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'fontOpacity' );
         }
 
-        getPXRange() {
-            return this._getProperty( 'pxRange' );
+        getFontPXRange() {
+            return this._getProperty( 'fontPXRange' );
         }
 
         getBorderRadius() {

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -183,6 +183,10 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'fontOpacity' );
         }
 
+        getPXRange() {
+            return this._getProperty( 'pxRange' );
+        }
+
         getBorderRadius() {
             return this._getProperty( 'borderRadius' );
         }

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -179,6 +179,11 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'fontColor' );
         }
 
+        
+        getFontSupersampling() {
+            return this._getProperty( 'fontSupersampling' );
+        }
+
         getFontOpacity() {
             return this._getProperty( 'fontOpacity' );
         }
@@ -420,6 +425,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 case "fontColor" :
                 case "fontOpacity" :
+                case "fontSupersampling" :
                 case "offset" :
                 case "backgroundColor" :
                 case "backgroundOpacity" :

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -19,7 +19,7 @@ export default {
 	textType: "MSDF",
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,
-	pxRange: 4,
+	fontPXRange: 4,
 	fontSupersampling: true,
 	borderRadius: 0.01,
 	borderWidth: 0,

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -19,6 +19,7 @@ export default {
 	textType: "MSDF",
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,
+	pxRange: 4,
 	borderRadius: 0.01,
 	borderWidth: 0,
 	borderColor: new Color( 'black' ),

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -20,6 +20,7 @@ export default {
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,
 	pxRange: 4,
+	fontSupersampling: true,
 	borderRadius: 0.01,
 	borderWidth: 0,
 	borderColor: new Color( 'black' ),


### PR DESCRIPTION

So it's been a while I'm unsatisfied with how text is drawn on low res display (important for cheap VR heasets).
I referred to [the repo](https://github.com/Chlumsky/msdfgen#using-a-multi-channel-distance-field) of the original MSDF technic to get better distance field functions, and the result look really good !

## before:
![not antialiased](https://user-images.githubusercontent.com/46470486/149995967-869d43c6-d39a-484b-b9c3-f3d5e9e502c4.jpg)

## after:
![antialiased](https://user-images.githubusercontent.com/46470486/149995990-12507cdc-40af-4b02-bfd8-d0ff43c08306.jpg)

There is some artifacts when the character is really tiny, but it's still much better than before IMO.

