### PR TITLE
improve frames antialiasing

### DIFF
--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -433,16 +433,22 @@ const backgroundFragment = `
     }
 
 	void main() {
+
         float edgeDist = getEdgeDist();
-        if ( edgeDist > 0.0 ) discard;
+        float change = fwidth( edgeDist );
+
 		vec4 textureSample = sampleTexture();
-        float blendedOpacity = u_opacity * textureSample.a;
         vec3 blendedColor = textureSample.rgb * u_color;
+
+        float alpha = smoothstep( change, 0.0, edgeDist );
+        float blendedOpacity = u_opacity * textureSample.a * alpha;
+
         if ( edgeDist * -1.0 < u_borderWidth ) {
-        gl_FragColor = vec4( u_borderColor, u_borderOpacity );
+            gl_FragColor = vec4( u_borderColor, u_borderOpacity * alpha );
         } else {
-		gl_FragColor = vec4( blendedColor, blendedOpacity );
+            gl_FragColor = vec4( blendedColor, blendedOpacity );
 		}
+
 		#include <clipping_planes_fragment>
 	}
 `;

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -443,11 +443,10 @@ const backgroundFragment = `
         float alpha = smoothstep( change, 0.0, edgeDist );
         float blendedOpacity = u_opacity * textureSample.a * alpha;
 
-        if ( edgeDist * -1.0 < u_borderWidth ) {
-            gl_FragColor = vec4( u_borderColor, u_borderOpacity * alpha );
-        } else {
-            gl_FragColor = vec4( blendedColor, blendedOpacity );
-		}
+        vec4 borderColor = vec4( u_borderColor, u_borderOpacity * alpha );
+        vec4 frameColor = vec4( blendedColor, blendedOpacity );
+        float stp = smoothstep( edgeDist + change, edgeDist, u_borderWidth * -1.0 );
+        gl_FragColor = mix( frameColor, borderColor, stp );
 
 		#include <clipping_planes_fragment>
 	}

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -443,10 +443,15 @@ const backgroundFragment = `
         float alpha = smoothstep( change, 0.0, edgeDist );
         float blendedOpacity = u_opacity * textureSample.a * alpha;
 
-        vec4 borderColor = vec4( u_borderColor, u_borderOpacity * alpha );
         vec4 frameColor = vec4( blendedColor, blendedOpacity );
-        float stp = smoothstep( edgeDist + change, edgeDist, u_borderWidth * -1.0 );
-        gl_FragColor = mix( frameColor, borderColor, stp );
+
+        if ( u_borderWidth <= 0.0 ) {
+            gl_FragColor = frameColor;
+        } else {
+            vec4 borderColor = vec4( u_borderColor, u_borderOpacity * alpha );
+            float stp = smoothstep( edgeDist + change, edgeDist, u_borderWidth * -1.0 );
+            gl_FragColor = mix( frameColor, borderColor, stp );
+        }
 
 		#include <clipping_planes_fragment>
 	}


### PR DESCRIPTION

Smooth out the edges of frames and the line between the frames background and border.

## before:
![Screenshot_3](https://user-images.githubusercontent.com/46470486/150112656-cf26449e-d1d4-4934-9847-27647768f885.jpg)

## after:
![Screenshot_2](https://user-images.githubusercontent.com/46470486/150112619-a75b3948-106a-484b-bd52-487312c094bd.jpg)

combined with #125 it will give three-mesh-ui objects a much more polished look.