### PR TITLE
Add Rotated grid super sampling for better font readability

### DIFF
--- a/config/webpack.prodConfig.js
+++ b/config/webpack.prodConfig.js
@@ -19,6 +19,7 @@ let pages = [
 	['keyboard', 'keyboard'],
 	['letter_spacing', 'letter spacing'],
 	['font_kerning', 'font kerning'],
+	['antialiasing', 'antialiasing'],
 ];
 
 // create one config for each of the data set above
@@ -76,6 +77,7 @@ module.exports = env => {
 			keyboard: './examples/keyboard.js',
 			letter_spacing: './examples/letter_spacing.js',
 			font_kerning: './examples/font_kerning.js',
+			antialiasing: './examples/antialiasing.js',
 		},
 
 		plugins: pagesConfig,

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -1,0 +1,129 @@
+
+import * as THREE from 'three';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BoxLineGeometry } from 'three/examples/jsm/geometries/BoxLineGeometry.js';
+
+import ThreeMeshUI from '../src/three-mesh-ui.js';
+
+import FontJSON from './assets/Roboto-msdf.json';
+import FontImage from './assets/Roboto-msdf.png';
+
+const WIDTH = window.innerWidth;
+const HEIGHT = window.innerHeight;
+
+let scene, camera, renderer, controls ;
+
+const textContent = "The males of this species grow to maximum total length of 73 cm (29 in): body 58 cm (23 in), tail 15 cm (5.9 in). Females grow to a maximum total length of 58 cm (23 in). The males are surprisingly long and slender compared to the females.\nThe head has a short snout, more so in males than in females.\nThe eyes are large and surrounded by 9–16 circumorbital scales. The orbits (eyes) are separated by 7–9 scales.";
+
+window.addEventListener('load', init );
+window.addEventListener('resize', onWindowResize );
+
+//
+
+function init() {
+
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color( 0x505050 );
+
+  camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 100 );
+
+  renderer = new THREE.WebGLRenderer({
+    antialias: true
+  });
+  renderer.setPixelRatio( window.devicePixelRatio );
+  renderer.setSize( WIDTH, HEIGHT );
+  renderer.xr.enabled = true;
+  document.body.appendChild(VRButton.createButton(renderer));
+  document.body.appendChild( renderer.domElement );
+
+  controls = new OrbitControls( camera, renderer.domElement );
+  camera.position.set( 0, 1.6, 0 );
+  controls.target = new THREE.Vector3( 0, 1, -1.8 );
+  controls.update();
+
+  // ROOM
+
+  const room = new THREE.LineSegments(
+    new BoxLineGeometry( 20, 20, 20, 10, 10, 10 ).translate( 0, 3, 0 ),
+    new THREE.LineBasicMaterial( { color: 0x808080 } )
+  );
+
+  scene.add( room );
+
+  // TEXT PANEL
+
+  const text01 = makeTextPanel();
+  text01.position.set(-1,0.5,-4);
+  text01.rotation.y = 0.9;
+
+  const text02 = makeTextPanel();
+  text02.position.set(1.5,0,-6);
+  text02.rotation.x = -0.55;
+
+  const text03 = makeTextPanel();
+  text03.position.set(0,0,-3);
+  text03.rotation.x = -0.55;
+
+  const text04 = makeTextPanel();
+  text04.position.set(1.5,1,-8);
+  text04.rotation.x = -0.55;
+  text04.rotation.y = -0.9;
+
+  const text05 = makeTextPanel();
+  text05.position.set(0,2,-8);
+  text05.rotation.x = -0.55;
+  text05.rotation.z = -0.9;
+
+  //
+
+  renderer.setAnimationLoop( loop );
+
+};
+
+//
+
+function makeTextPanel() {
+
+  const container = new ThreeMeshUI.Block({
+    width: 1.8,
+    height: 0.5,
+    padding: 0.05,
+    justifyContent: 'center',
+    alignContent: 'left',
+    fontFamily: FontJSON,
+    fontTexture: FontImage
+  });
+
+  scene.add( container );
+
+  container.add(
+    new ThreeMeshUI.Text({
+      content: textContent,
+      fontKerning: "normal"
+    }),
+  );
+
+  return container;
+};
+
+// handles resizing the renderer when the viewport is resized
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize( window.innerWidth, window.innerHeight );
+};
+
+//
+
+function loop() {
+
+  // Don't forget, ThreeMeshUI must be updated manually.
+  // This has been introduced in version 3.0.0 in order
+  // to improve performance
+  ThreeMeshUI.update();
+
+  controls.update();
+  renderer.render( scene, camera );
+};

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -27,7 +27,7 @@ function init() {
   scene = new THREE.Scene();
   scene.background = new THREE.Color( 0x000000 );
 
-  camera = new THREE.PerspectiveCamera( 3, WIDTH / HEIGHT, 0.1, 500 );
+  camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 500 );
 
   renderer = new THREE.WebGLRenderer({
     antialias: true
@@ -39,7 +39,7 @@ function init() {
   document.body.appendChild( renderer.domElement );
 
   controls = new OrbitControls( camera, renderer.domElement );
-  camera.position.set( 0, 1.0, 100.0 );
+  camera.position.set( 0, 1.0, 1.0 );
   controls.target = new THREE.Vector3( 0, 1, 0 );
   controls.update();
 
@@ -50,12 +50,14 @@ function init() {
     new THREE.LineBasicMaterial( { color: 0x808080 } )
   );
 
-  scene.add( room );
+  // scene.add( room );
 
   // TEXT PANEL
 
   // attempt to have a pixel-perfect match to the reference MSDF implementation
-  makeTextPanel(0.024,.1,-2,0,0,0);
+  
+  makeTextPanel(0.024,.1,-2,0,0,0,true);
+  makeTextPanel(2.024,.1,-2,0,0,0,false);
 
   makeTextPanel(0,0,-3,0,0,0);
   makeTextPanel(0,0,-5,0,0,0);
@@ -65,9 +67,15 @@ function init() {
   makeTextPanel(-1.5,0.5,-4,0,0.9,0);
   makeTextPanel(-1.5,1.1,-4,0,1.3,0);
   makeTextPanel(-1.5,1.7,-4,0,1.6,0);
+  makeTextPanel(-2.5,0.5,-4,0,0.9,0, true);
+  makeTextPanel(-2.5,1.1,-4,0,1.3,0, true);
+  makeTextPanel(-2.5,1.7,-4,0,1.6,0, true);
+
+
   makeTextPanel(2.0,0,-3,-1,0,0);
   makeTextPanel(2.0,0,-5,-1,0,0);
   makeTextPanel(2.4,0.1,-7,-1,0,0);
+  
   makeTextPanel(1.5,1,-8,-0.55,-0.9,0);
   makeTextPanel(0,1.2,-8,-0.55,0,-0.9);
   makeTextPanel(0,1.75,-5,-0.55,0,-0.9);
@@ -81,7 +89,7 @@ function init() {
 
 //
 
-function makeTextPanel(x,y,z,rotX, rotY, rotZ) {
+function makeTextPanel(x,y,z,rotX, rotY, rotZ, supersample) {
 
   const container = new ThreeMeshUI.Block({
     width: 2.0,
@@ -94,6 +102,7 @@ function makeTextPanel(x,y,z,rotX, rotY, rotZ) {
     fontColor: new THREE.Color( 0xffffff ),
     backgroundOpacity: 1,
     backgroundColor: new THREE.Color( 0x000000 ),
+    fontSupersampling: supersample,
   });
 
   scene.add( container );

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -14,7 +14,8 @@ const HEIGHT = window.innerHeight;
 
 let scene, camera, renderer, controls ;
 
-const textContent = "The males of this species grow to maximum total length of 73 cm (29 in): body 58 cm (23 in), tail 15 cm (5.9 in). Females grow to a maximum total length of 58 cm (23 in). The males are surprisingly long and slender compared to the females.\nThe head has a short snout, more so in males than in females.\nThe eyes are large and surrounded by 9–16 circumorbital scales. The orbits (eyes) are separated by 7–9 scales.";
+const textContent = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-:?!
+The males of this species grow to maximum total length of 73 cm (29 in): body 58 cm (23 in), tail 15 cm (5.9 in). Females grow to a maximum total length of 58 cm (23 in). The males are surprisingly long and slender compared to the females.\nThe head has a short snout, more so in males than in females.\nThe eyes are large and surrounded by 9–16 circumorbital scales. The orbits (eyes) are separated by 7–9 scales.`;
 
 window.addEventListener('load', init );
 window.addEventListener('resize', onWindowResize );
@@ -24,9 +25,9 @@ window.addEventListener('resize', onWindowResize );
 function init() {
 
   scene = new THREE.Scene();
-  scene.background = new THREE.Color( 0x505050 );
+  scene.background = new THREE.Color( 0x000000 );
 
-  camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 100 );
+  camera = new THREE.PerspectiveCamera( 3, WIDTH / HEIGHT, 0.1, 500 );
 
   renderer = new THREE.WebGLRenderer({
     antialias: true
@@ -38,8 +39,8 @@ function init() {
   document.body.appendChild( renderer.domElement );
 
   controls = new OrbitControls( camera, renderer.domElement );
-  camera.position.set( 0, 1.0, 0 );
-  controls.target = new THREE.Vector3( 0, 1, -1.8 );
+  camera.position.set( 0, 1.0, 100.0 );
+  controls.target = new THREE.Vector3( 0, 1, 0 );
   controls.update();
 
   // ROOM
@@ -53,7 +54,9 @@ function init() {
 
   // TEXT PANEL
 
-  makeTextPanel(0,0,-2,0,0,0);
+  // attempt to have a pixel-perfect match to the reference MSDF implementation
+  makeTextPanel(0.024,.1,-2,0,0,0);
+
   makeTextPanel(0,0,-3,0,0,0);
   makeTextPanel(0,0,-5,0,0,0);
   makeTextPanel(0,0,-7,0,0,0);
@@ -81,13 +84,16 @@ function init() {
 function makeTextPanel(x,y,z,rotX, rotY, rotZ) {
 
   const container = new ThreeMeshUI.Block({
-    width: 1.8,
-    height: 0.5,
+    width: 2.0,
+    height: 0.6,
     padding: 0.05,
     justifyContent: 'center',
     alignContent: 'left',
     fontFamily: FontJSON,
-    fontTexture: FontImage
+    fontTexture: FontImage,
+    fontColor: new THREE.Color( 0xffffff ),
+    backgroundOpacity: 1,
+    backgroundColor: new THREE.Color( 0x000000 ),
   });
 
   scene.add( container );
@@ -97,7 +103,8 @@ function makeTextPanel(x,y,z,rotX, rotY, rotZ) {
   container.add(
     new ThreeMeshUI.Text({
       content: textContent,
-      fontKerning: "normal"
+      fontKerning: "normal",
+      fontSize: 0.045,
     }),
   );
 
@@ -125,7 +132,7 @@ function loop() {
 
   // swinging motion to see motion aliasing better
   let time = clock.getElapsedTime();
-  controls.target.set(Math.sin(time * 20) * 0.001, 1, -1.8 );
+  //controls.target.set(Math.sin(time * 20) * 0.001, 1, -1.8 );
   controls.update();
   renderer.render( scene, camera );
 };

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -132,7 +132,7 @@ function loop() {
 
   // swinging motion to see motion aliasing better
   let time = clock.getElapsedTime();
-  //controls.target.set(Math.sin(time * 20) * 0.001, 1, -1.8 );
+  controls.target.set(Math.sin(time * 21) * 0.0031, 1 + Math.sin(time * 23) * 0.0023, -1.8 );
   controls.update();
   renderer.render( scene, camera );
 };

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -38,7 +38,7 @@ function init() {
   document.body.appendChild( renderer.domElement );
 
   controls = new OrbitControls( camera, renderer.domElement );
-  camera.position.set( 0, 1.6, 0 );
+  camera.position.set( 0, 1.0, 0 );
   controls.target = new THREE.Vector3( 0, 1, -1.8 );
   controls.update();
 
@@ -53,27 +53,22 @@ function init() {
 
   // TEXT PANEL
 
-  const text01 = makeTextPanel();
-  text01.position.set(-1,0.5,-4);
-  text01.rotation.y = 0.9;
-
-  const text02 = makeTextPanel();
-  text02.position.set(1.5,0,-6);
-  text02.rotation.x = -0.55;
-
-  const text03 = makeTextPanel();
-  text03.position.set(0,0,-3);
-  text03.rotation.x = -0.55;
-
-  const text04 = makeTextPanel();
-  text04.position.set(1.5,1,-8);
-  text04.rotation.x = -0.55;
-  text04.rotation.y = -0.9;
-
-  const text05 = makeTextPanel();
-  text05.position.set(0,2,-8);
-  text05.rotation.x = -0.55;
-  text05.rotation.z = -0.9;
+  makeTextPanel(0,0,-2,0,0,0);
+  makeTextPanel(0,0,-3,0,0,0);
+  makeTextPanel(0,0,-5,0,0,0);
+  makeTextPanel(0,0,-7,0,0,0);
+  makeTextPanel(0,0,-9,0,0,0);
+  
+  makeTextPanel(-1.5,0.5,-4,0,0.9,0);
+  makeTextPanel(-1.5,1.1,-4,0,1.3,0);
+  makeTextPanel(-1.5,1.7,-4,0,1.6,0);
+  makeTextPanel(2.0,0,-3,-1,0,0);
+  makeTextPanel(2.0,0,-5,-1,0,0);
+  makeTextPanel(2.4,0.1,-7,-1,0,0);
+  makeTextPanel(1.5,1,-8,-0.55,-0.9,0);
+  makeTextPanel(0,1.2,-8,-0.55,0,-0.9);
+  makeTextPanel(0,1.75,-5,-0.55,0,-0.9);
+  makeTextPanel(0,2.0,-3,-0.55,0,-0.9);
 
   //
 
@@ -83,7 +78,7 @@ function init() {
 
 //
 
-function makeTextPanel() {
+function makeTextPanel(x,y,z,rotX, rotY, rotZ) {
 
   const container = new ThreeMeshUI.Block({
     width: 1.8,
@@ -96,6 +91,8 @@ function makeTextPanel() {
   });
 
   scene.add( container );
+  container.position.set(x,y,z);
+  container.rotation.set(rotX, rotY, rotZ);
 
   container.add(
     new ThreeMeshUI.Text({
@@ -116,6 +113,8 @@ function onWindowResize() {
 };
 
 //
+var clock = new THREE.Clock(true);
+clock.start();
 
 function loop() {
 
@@ -124,6 +123,9 @@ function loop() {
   // to improve performance
   ThreeMeshUI.update();
 
+  // swinging motion to see motion aliasing better
+  let time = clock.getElapsedTime();
+  controls.target.set(Math.sin(time * 20) * 0.001, 1, -1.8 );
   controls.update();
   renderer.render( scene, camera );
 };

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -323,10 +323,16 @@ const textFragment = `
 		return max(min(r, g), min(max(r, g), b));
 	}
 
+    #ifdef USE_RGSS
+    #define RANGE 2.0
+    #else
+    #define RANGE 1.0
+    #endif
+
     float screenPxRange() {
         float pxRange = 4.0; // not sure what this variable is about...
 
-        vec2 unitRange = 2.0 * vec2(pxRange)/vec2(textureSize(u_texture, 0));
+        vec2 unitRange = RANGE * vec2(pxRange)/vec2(textureSize(u_texture, 0));
         vec2 screenTexSize = vec2(1.0)/fwidth(vUv);
         return max(0.5*dot(unitRange, screenTexSize), 1.0);
     }

--- a/src/components/core/MaterialManager.js
+++ b/src/components/core/MaterialManager.js
@@ -228,6 +228,9 @@ export default function MaterialManager( Base = class {} ) {
                 fragmentShader: textFragment,
                 extensions: {
                     derivatives: true
+                },
+                defines: {
+                    USE_RGSS: true,
                 }
             })
 
@@ -329,7 +332,34 @@ const textFragment = `
     }
 
     void main() {
+#ifdef USE_RGSS
+        // shader-based supersampling based on https://bgolus.medium.com/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
+        // per pixel partial derivatives
+        vec2 dx = dFdx(vUv);
+        vec2 dy = dFdy(vUv);
+
+        // rotated grid uv offsets
+        vec2 uvOffsets = vec2(0.125, 0.375);
+        float _Bias = -0.5;
+        vec2 offsetUV = vec2(0.0, 0.0);
+
+        // supersampled using 2x2 rotated grid
+        vec4 col = vec4(0.0);
+        offsetUV.xy = vUv + uvOffsets.x * dx + uvOffsets.y * dy;
+        col += texture(u_texture, offsetUV, _Bias);
+        offsetUV.xy = vUv - uvOffsets.x * dx - uvOffsets.y * dy;
+        col += texture(u_texture, offsetUV, _Bias);
+        offsetUV.xy = vUv + uvOffsets.y * dx - uvOffsets.x * dy;
+        col += texture(u_texture, offsetUV, _Bias);
+        offsetUV.xy = vUv - uvOffsets.y * dx + uvOffsets.x * dy;
+        col += texture(u_texture, offsetUV, _Bias);
+        col *= 0.25;
+
+        vec3 msd = col.rgb;
+#else
         vec3 msd = texture( u_texture, vUv ).rgb;
+#endif
+
         float sd = median(msd.r, msd.g, msd.b);
         float screenPxDistance = screenPxRange()*(sd - 0.5);
         float alpha = clamp(screenPxDistance + 0.5, 0.0, 1.0);

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -179,6 +179,11 @@ export default function MeshUIComponent( Base = class {} ) {
             return this._getProperty( 'fontColor' );
         }
 
+        
+        getFontSupersampling() {
+            return this._getProperty( 'fontSupersampling' );
+        }
+
         getFontOpacity() {
             return this._getProperty( 'fontOpacity' );
         }
@@ -416,6 +421,7 @@ export default function MeshUIComponent( Base = class {} ) {
 
                 case "fontColor" :
                 case "fontOpacity" :
+                case "fontSupersampling" :
                 case "offset" :
                 case "backgroundColor" :
                 case "backgroundOpacity" :

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -19,7 +19,7 @@ export default {
 	textType: "MSDF",
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,
-	fontSupersampling: false,
+	fontSupersampling: true,
 	borderRadius: 0.01,
 	borderWidth: 0,
 	borderColor: new Color( 'black' ),

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -19,6 +19,7 @@ export default {
 	textType: "MSDF",
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,
+	fontSupersampling: false,
 	borderRadius: 0.01,
 	borderWidth: 0,
 	borderColor: new Color( 'black' ),


### PR DESCRIPTION
Wanted to add this for a while, seems there's an effort to improve font rendering already, so added it this branch here!

In Unity, we've been using https://bgolus.medium.com/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec for much increased font quality in VR; this should trade a few more texture samples against much increased quality.

I'm not entirely sure how to apply it for the MSDF font though; quality increases slightly but not as much as I had expected.
I've got another branch on master (https://github.com/needle-tools/three-mesh-ui/blob/29324f8d795c140ab039f9a571ae8e770aaf6a84/src/components/core/MaterialManager.js#L332) where the increase is much more pronounced, so I think something needs to be done a bit differently with MSDF.

I also opened a question at the MSDF repo in case there are any hints on what the correct place to apply supersampling would be: https://github.com/Chlumsky/msdfgen/discussions/141

The feature can be turned on/off via a define (currently USE_RGSS), and I added a very basic antialising sample scene.

Related to https://github.com/felixmariotto/three-mesh-ui/pull/125