### PR TITLE
removing unnecessary best fit condition.

### DIFF
--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -409,7 +409,7 @@ export default function MeshUIComponent( Base = class {} ) {
                         break;
 
                     case "bestFit" :
-                        if ( this.isBlock && options[ prop ] == true ) {
+                        if ( this.isBlock ) {
                             parsingNeedsUpdate = true;
                             layoutNeedsUpdate = true;
                         }

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -426,11 +426,9 @@ export default function MeshUIComponent( Base = class {} ) {
 
                     case "letterSpacing" :
                     case "interLine" :
-                        if ( this.isBlock && this[ "bestFit" ] == true ) {
-                            parsingNeedsUpdate = true;
-                            layoutNeedsUpdate = true;
-                            this[ prop ] = options[ prop ];
-                        }
+                        if ( this.isBlock && this[ "bestFit" ] == true ) parsingNeedsUpdate = true;
+                        layoutNeedsUpdate = true;
+                        this[ prop ] = options[ prop ];
                         break;
 
                     case "margin" :


### PR DESCRIPTION
The condition I'm removing actually stopped the logic from running when setting a best fit value since we no longer use true / false. Parsing and layout updates should happen whenever the value is changed anyway.

sorry for not catching this before we merged the previous PR.