### PR TITLE
add default borderOpacity

### DIFF
--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -25,6 +25,7 @@ export default {
 	borderRadius: 0.01,
 	borderWidth: 0,
 	borderColor: new Color( 'black' ),
+	borderOpacity: 1,
 	backgroundSize: "cover",
 	backgroundColor: new Color( 0x222222 ),
 	backgroundWhiteColor: new Color( 0xffffff ),


### PR DESCRIPTION

There was no default for the `borderOpacity`.
IMO it should be 1 because the default `borderWidth` is 0, which makes the border invisible.
If somebody wants to set a `borderWidth` higher than 0, then chances are that they want an Opacity of 1.