### PR TITLE
Update to Defaults Background Texture generation

### DIFF
--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -37,16 +37,19 @@ export default {
 };
 
 //
+var defaultBgTexture;
 
 function makeBackgroundTexture() {
 
-	const ctx = document.createElement('canvas').getContext('2d');
-	ctx.canvas.width = 1;
-	ctx.canvas.height = 1;
-	ctx.fillStyle = '#ffffff';
-	ctx.fillRect(0, 0, 1, 1);
-	const texture = new CanvasTexture(ctx.canvas);
-	texture.isDefault = true;
-	return texture;
+	if(!defaultBgTexture) {
+		const ctx = document.createElement('canvas').getContext('2d');
+		ctx.canvas.width = 1;
+		ctx.canvas.height = 1;
+		ctx.fillStyle = '#ffffff';
+		ctx.fillRect(0, 0, 1, 1);
+		defaultBgTexture = new CanvasTexture(ctx.canvas);
+		defaultBgTexture.isDefault = true;
+	}
 
+	return defaultBgTexture;
 }


### PR DESCRIPTION
Updates `makeBackgroundTexture` in `Defaults.js` to create default background texture only once, otherwise returns existing texture cached in the Default module. Solves #147 without stepping over the work to solve #126. See the video below showing three.js renderer texture count remaining consistent. You can test this as well by recreating the test following my steps here -  https://github.com/felixmariotto/three-mesh-ui/issues/147#issuecomment-1022534664

https://user-images.githubusercontent.com/83366171/151254208-2f186cea-a226-4f9a-8549-d75936793268.mp4
