### PR TITLE
Feature/justification spacing

### DIFF
--- a/config/webpack.prodConfig.js
+++ b/config/webpack.prodConfig.js
@@ -21,7 +21,8 @@ let pages = [
 	['font_kerning', 'font kerning'],
 	['best_fit', 'best fit'],
 	['antialiasing', 'antialiasing'],
-	['justification', 'justification']
+	['justification', 'justification'],
+	['text_align', 'Text Align'],
 ];
 
 // create one config for each of the data set above
@@ -81,7 +82,8 @@ module.exports = env => {
 			font_kerning: './examples/font_kerning.js',
 			best_fit: './examples/best_fit.js',
 			antialiasing: './examples/antialiasing.js',
-			justification: './examples/justification.js'
+			justification: './examples/justification.js',
+			text_align: './examples/text_align.js'
 		},
 
 		plugins: pagesConfig,

--- a/config/webpack.prodConfig.js
+++ b/config/webpack.prodConfig.js
@@ -19,8 +19,9 @@ let pages = [
 	['keyboard', 'keyboard'],
 	['letter_spacing', 'letter spacing'],
 	['font_kerning', 'font kerning'],
-    ['best_fit', 'best fit'],
+	['best_fit', 'best fit'],
 	['antialiasing', 'antialiasing'],
+	['justification', 'justification']
 ];
 
 // create one config for each of the data set above
@@ -78,8 +79,9 @@ module.exports = env => {
 			keyboard: './examples/keyboard.js',
 			letter_spacing: './examples/letter_spacing.js',
 			font_kerning: './examples/font_kerning.js',
-            best_fit: './examples/best_fit.js',
+			best_fit: './examples/best_fit.js',
 			antialiasing: './examples/antialiasing.js',
+			justification: './examples/justification.js'
 		},
 
 		plugins: pagesConfig,

--- a/examples/antialiasing.js
+++ b/examples/antialiasing.js
@@ -76,7 +76,7 @@ function makeTextPanel( x, rotX, rotY, rotZ, supersample ) {
 		padding: 0.05,
 		borderRadius: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		alignItems: 'start',
 		fontFamily: FontJSON,
 		fontTexture: FontImage,
 		fontColor: new THREE.Color( 0xffffff ),

--- a/examples/basic_setup.js
+++ b/examples/basic_setup.js
@@ -67,7 +67,7 @@ function makeTextPanel() {
 		height: 0.5,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		fontFamily: FontJSON,
 		fontTexture: FontImage
 	} );

--- a/examples/best_fit.js
+++ b/examples/best_fit.js
@@ -171,7 +171,7 @@ function makeTextPanel() {
 			borderOpacity: 1,
 			borderColor: new THREE.Color( 0x333333 ),
 			justifyContent: 'end',
-			alignContent: 'right',
+			alignItems: 'right',
 			fontColor: new THREE.Color( 0x111111 ),
 			fontFamily: FontJSON,
 			fontTexture: FontImage,

--- a/examples/best_fit.js
+++ b/examples/best_fit.js
@@ -171,7 +171,7 @@ function makeTextPanel() {
 			borderOpacity: 1,
 			borderColor: new THREE.Color( 0x333333 ),
 			justifyContent: 'end',
-			alignItems: 'right',
+			alignItems: 'end',
 			fontColor: new THREE.Color( 0x111111 ),
 			fontFamily: FontJSON,
 			fontTexture: FontImage,

--- a/examples/border.js
+++ b/examples/border.js
@@ -67,7 +67,7 @@ function makeTextPanel() {
 		height: 0.8,
 		fontSize: 0.055,
 		justifyContent: 'center',
-		alignContent: 'center',
+		textAlign: 'center',
 		fontFamily: FontJSON,
 		fontTexture: FontImage
 	} );

--- a/examples/font_kerning.js
+++ b/examples/font_kerning.js
@@ -67,7 +67,7 @@ function makeTextPanel() {
 		height: 0.3,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		fontFamily: FontJSON,
 		fontTexture: FontImage
 	} );

--- a/examples/hidden_overflow.js
+++ b/examples/hidden_overflow.js
@@ -88,7 +88,6 @@ function makeTextPanel() {
 		width: 0.6,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'center',
 		backgroundOpacity: 1,
 		backgroundColor: new THREE.Color( 'grey' )
 	} );

--- a/examples/inline_block.js
+++ b/examples/inline_block.js
@@ -66,7 +66,7 @@ function makeTextPanel() {
 		height: 0.95,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		fontFamily: FontJSON,
 		fontTexture: FontImage,
 		fontSize: 0.05,

--- a/examples/interactive_button.js
+++ b/examples/interactive_button.js
@@ -202,7 +202,6 @@ function makePanel() {
 
 	const container = new ThreeMeshUI.Block( {
 		justifyContent: 'center',
-		alignContent: 'center',
 		contentDirection: 'row-reverse',
 		fontFamily: FontJSON,
 		fontTexture: FontImage,
@@ -224,7 +223,6 @@ function makePanel() {
 		width: 0.4,
 		height: 0.15,
 		justifyContent: 'center',
-		alignContent: 'center',
 		offset: 0.05,
 		margin: 0.02,
 		borderRadius: 0.075

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -225,6 +225,30 @@ setInterval( ()=>{
 
 }, 1000 );
 
+let sizeMode = 1;
+let sizes = [0.125,0.25,0.375,0.5];
+
+setInterval( ()=>{
+	console.log("Dize")
+	sizeMode += 1;
+	sizeMode = sizeMode >= sizes.length ? 0 : sizeMode;
+
+	const mode = sizes[sizeMode];
+	console.log(mode);
+	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
+		for ( let j = 1; j < justifyInRow.children[ i ].children.length; j++ ) {
+			justifyInRow.children[ i ].children[ j ].set({width:mode});
+		}
+
+	}
+
+	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
+		for ( let j = 1; j < justifyInColumn.children[ i ].children.length; j++ ) {
+			justifyInColumn.children[ i ].children[ j ].set({height:mode});
+		}
+	}
+
+}, 3000 );
 
 let currentBigSize = DIM_HIGH;
 let currentSpeed = -0.005;

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -143,10 +143,10 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 		} );
 		panel.add( blockText );
 
-		const text = new ThreeMeshUI.Text( {
-			content: letters[ i ]
-		} );
-		blockText.add( text );
+		// const text = new ThreeMeshUI.Text( {
+		// 	content: letters[ i ]
+		// } );
+		// blockText.add( text );
 
 	}
 
@@ -242,13 +242,10 @@ const sizes = [ 0.125, 0.175, 0.225, 0.295 ];
 
 setInterval( () => {
 
-	// console.log( "Dize" );
-
 	sizeMode += 1;
 	sizeMode = sizeMode >= sizes.length ? 0 : sizeMode;
 
 	const mode = sizes[ sizeMode ];
-	// console.log( mode );
 
 	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
 

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -226,7 +226,7 @@ setInterval( ()=>{
 }, 1000 );
 
 let sizeMode = 1;
-let sizes = [0.125,0.25,0.375,0.5];
+let sizes = [0.125,0.175,0.225,0.295];
 
 setInterval( ()=>{
 	console.log("Dize")

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -139,7 +139,7 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 			borderRadius: 0.02,
 			backgroundColor: color,
 			justifyContent: 'center',
-			alignContent: 'center'
+			alignItems: 'center'
 		} );
 		panel.add( blockText );
 
@@ -225,13 +225,13 @@ setInterval( () => {
 
 	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
 
-		justifyInRow.children[ i ].set( { alignContent: mode } );
+		justifyInRow.children[ i ].set( { alignItems: mode } );
 
 	}
 
 	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
 
-		justifyInColumn.children[ i ].set( { alignContent: mode } );
+		justifyInColumn.children[ i ].set( { alignItems: mode } );
 
 	}
 

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -75,10 +75,10 @@ function init() {
 	justifyInColumn = makeTextPanel( 'row' );
 
 	justifyInRow.position.x = -0.75;
-	justifyInRow.scale.setScalar(0.75);
+	justifyInRow.scale.setScalar( 0.75 );
 
 	justifyInColumn.position.x = 0.75;
-	justifyInColumn.scale.setScalar(0.75);
+	justifyInColumn.scale.setScalar( 0.75 );
 
 	//
 
@@ -87,7 +87,6 @@ function init() {
 }
 
 function makeTextPanel( contentDirection ) {
-//
 
 	container = new ThreeMeshUI.Block( {
 		height: DIM_HIGH + 0.2,
@@ -102,13 +101,14 @@ function makeTextPanel( contentDirection ) {
 	} );
 
 	container.position.set( 0, 1, -1.8 );
-	container.rotation.x = -0.55;
+	container.rotation.x = - 0.55;
 	scene.add( container );
 
-	for ( let i = 0; i < justificationLegend.length; i++ ) {
+	for ( let i = 0; i < justificationLegend.length; i ++ ) {
+
 		const color = new THREE.Color( justificationLegend[ i ].color );
 		const id = justificationLegend[ i ].id;
-		const panel = buildJustifiedPanel( id, color , contentDirection === 'column' ? 'row' : 'column'  );
+		const panel = buildJustifiedPanel( id, color, contentDirection === 'column' ? 'row' : 'column' );
 
 		container.add( panel );
 	}
@@ -129,7 +129,9 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 	container.add( panel );
 
 	const letters = 'ABCDEF';
-	for ( let i = 0; i < 5; i++ ) {
+
+	for ( let i = 0; i < 5; i ++ ) {
+
 		const blockText = new ThreeMeshUI.Block( {
 			width: 0.125,
 			height: 0.125,
@@ -145,12 +147,14 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 			content: letters[ i ]
 		} );
 		blockText.add( text );
+
 	}
 
 	return panel;
 }
 
 function makeTitlePanel(){
+
 	const panel = new ThreeMeshUI.Block( {
 		width: DIM_HIGH * 2,
 		height: 0.15,
@@ -162,18 +166,17 @@ function makeTitlePanel(){
 		fontTexture: FontImage
 	} );
 
+	for ( let i = 0; i < justificationLegend.length; i ++ ) {
 
-	for ( let i = 0; i < justificationLegend.length; i++ ) {
 		const color = new THREE.Color( justificationLegend[ i ].color );
 		const id = justificationLegend[ i ].id;
 
-		// const textContainer = new ThreeMeshUI.Block({});
-		// panel.add( textContainer );
-
-		panel.add( new ThreeMeshUI.Text({
-			content : id,
-			fontColor : color
-		}) )
+		panel.add(
+			new ThreeMeshUI.Text( {
+				content: id,
+				fontColor: color
+			} )
+		);
 
 	}
 
@@ -182,8 +185,8 @@ function makeTitlePanel(){
 
 	scene.add( panel );
 }
-// handles resizing the renderer when the viewport is resized
 
+// handles resizing the renderer when the viewport is resized
 function onWindowResize() {
 
 	camera.aspect = window.innerWidth / window.innerHeight;
@@ -193,86 +196,111 @@ function onWindowResize() {
 }
 
 //
-let isInverted = false;
-setInterval( ()=>{
-	isInverted = !isInverted;
 
-	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
-		justifyInRow.children[ i ].set({contentDirection:isInverted?'row-reverse':'row'});
+let isInverted = false;
+
+setInterval( () => {
+
+	isInverted = ! isInverted;
+
+	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
+		justifyInRow.children[ i ].set( { contentDirection:isInverted ? 'row-reverse' : 'row' } );
 	}
 
-	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
-		justifyInColumn.children[ i ].set({contentDirection:isInverted?'column-reverse':'column'});
+	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
+		justifyInColumn.children[ i ].set( { contentDirection:isInverted ? 'column-reverse' : 'column' } );
 	}
 
 }, 2500 );
 
 let alignMode = 1;
-let aligns = ['start','center','end'];
+const aligns = [ 'start', 'center', 'end' ];
 
-setInterval( ()=>{
+setInterval( () => {
+
 	alignMode += 1;
 	alignMode = alignMode >= aligns.length ? 0 : alignMode;
 
 	const mode = aligns[alignMode];
-	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
-		justifyInRow.children[ i ].set({alignContent:mode});
+
+	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
+
+		justifyInRow.children[ i ].set( { alignContent: mode } );
+
 	}
 
-	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
-		justifyInColumn.children[ i ].set({alignContent:mode});
+	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
+
+		justifyInColumn.children[ i ].set( { alignContent: mode } );
+
 	}
 
 }, 1000 );
 
 let sizeMode = 1;
-let sizes = [0.125,0.175,0.225,0.295];
+const sizes = [ 0.125, 0.175, 0.225, 0.295 ];
 
-setInterval( ()=>{
-	console.log("Dize")
+setInterval( () => {
+
+	// console.log( "Dize" );
+
 	sizeMode += 1;
 	sizeMode = sizeMode >= sizes.length ? 0 : sizeMode;
 
-	const mode = sizes[sizeMode];
-	console.log(mode);
-	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
-		for ( let j = 1; j < justifyInRow.children[ i ].children.length; j++ ) {
-			justifyInRow.children[ i ].children[ j ].set({width:mode});
+	const mode = sizes[ sizeMode ];
+	// console.log( mode );
+
+	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
+
+		for ( let j = 1; j < justifyInRow.children[ i ].children.length; j ++ ) {
+
+			justifyInRow.children[ i ].children[ j ].set( { width: mode } );
+
 		}
 
 	}
 
-	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
-		for ( let j = 1; j < justifyInColumn.children[ i ].children.length; j++ ) {
-			justifyInColumn.children[ i ].children[ j ].set({height:mode});
+	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
+
+		for ( let j = 1; j < justifyInColumn.children[ i ].children.length; j ++ ) {
+
+			justifyInColumn.children[ i ].children[ j ].set( { height:mode } );
+
 		}
 	}
 
 }, 3000 );
 
 let currentBigSize = DIM_HIGH;
-let currentSpeed = -0.005;
+let currentSpeed = - 0.005;
 
 function loop() {
 
-
 	currentBigSize += currentSpeed;
-	if( currentBigSize >= DIM_HIGH ){
+
+	if ( currentBigSize >= DIM_HIGH ) {
+
 		currentBigSize = DIM_HIGH;
-		currentSpeed *= -1;
-	}else if( currentBigSize <= MIN_HIGH ){
+		currentSpeed *= - 1;
+
+	} else if ( currentBigSize <= MIN_HIGH ) {
+
 		currentBigSize = MIN_HIGH;
 		currentSpeed *= -1;
+
 	}
 
-	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
-		justifyInRow.children[ i ].set({width:currentBigSize});
+	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
+
+		justifyInRow.children[ i ].set( { width: currentBigSize } );
+
 	}
 
-	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
-		justifyInColumn.children[ i ].set({height:currentBigSize});
-	}
+	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
 
+		justifyInColumn.children[ i ].set( { height: currentBigSize } );
+
+	}
 
 	// Don't forget, ThreeMeshUI must be updated manually.
 	// This has been introduced in version 3.0.0 in order

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -1,0 +1,263 @@
+import * as THREE from 'three';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BoxLineGeometry } from 'three/examples/jsm/geometries/BoxLineGeometry.js';
+
+import Stats from 'three/examples/jsm/libs/stats.module.js';
+
+import ThreeMeshUI from '../src/three-mesh-ui.js';
+
+import FontJSON from './assets/Roboto-msdf.json';
+import FontImage from './assets/Roboto-msdf.png';
+
+const WIDTH = window.innerWidth;
+const HEIGHT = window.innerHeight;
+
+let container, justifyInRow, justifyInColumn;
+const DIM_HIGH = 1.6;
+const MIN_HIGH = 1.1;
+
+const DIM_LOW = 0.25;
+
+const justificationLegend = [
+	{ id: 'start', color: 0xff9900 },
+	{ id: 'end', color: 0xff0099 },
+	{ id: 'center', color: 0x00ff99 },
+	{ id: "space-between", color: 0x99ff00 },
+	{ id: "space-around", color: 0x9900ff },
+	{ id: "space-evenly", color: 0x0099ff }
+];
+
+let scene, camera, renderer, controls, stats;
+
+window.addEventListener( 'load', init );
+window.addEventListener( 'resize', onWindowResize );
+
+//
+
+function init() {
+
+	scene = new THREE.Scene();
+	scene.background = new THREE.Color( 0x505050 );
+
+	camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 100 );
+
+	renderer = new THREE.WebGLRenderer( {
+		antialias: true
+	} );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( WIDTH, HEIGHT );
+	renderer.xr.enabled = true;
+	document.body.appendChild( VRButton.createButton( renderer ) );
+	document.body.appendChild( renderer.domElement );
+
+	stats = new Stats();
+	document.body.appendChild( stats.dom );
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	camera.position.set( 0, 1.6, 0 );
+	controls.target = new THREE.Vector3( 0, 1, -1.8 );
+	controls.update();
+
+	// ROOM
+
+	const room = new THREE.LineSegments(
+		new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ).translate( 0, 3, 0 ),
+		new THREE.LineBasicMaterial( { color: 0x808080 } )
+	);
+
+	scene.add( room );
+
+	// TEXT PANEL
+
+	makeTitlePanel();
+	justifyInRow = makeTextPanel( 'column' );
+	justifyInColumn = makeTextPanel( 'row' );
+
+	justifyInRow.position.x = -0.75;
+	justifyInRow.scale.setScalar(0.75);
+
+	justifyInColumn.position.x = 0.75;
+	justifyInColumn.scale.setScalar(0.75);
+
+	//
+
+	renderer.setAnimationLoop( loop );
+
+}
+
+function makeTextPanel( contentDirection ) {
+//
+
+	container = new ThreeMeshUI.Block( {
+		height: DIM_HIGH + 0.2,
+		width: DIM_HIGH + 0.2,
+		contentDirection: contentDirection,
+		justifyContent: 'center',
+		backgroundOpacity: 1,
+		backgroundColor: new THREE.Color( 'grey' ),
+		hiddenOverflow: true,
+		fontFamily: FontJSON,
+		fontTexture: FontImage
+	} );
+
+	container.position.set( 0, 1, -1.8 );
+	container.rotation.x = -0.55;
+	scene.add( container );
+
+	for ( let i = 0; i < justificationLegend.length; i++ ) {
+		const color = new THREE.Color( justificationLegend[ i ].color );
+		const id = justificationLegend[ i ].id;
+		const panel = buildJustifiedPanel( id, color , contentDirection === 'column' ? 'row' : 'column'  );
+
+		container.add( panel );
+	}
+
+	return container;
+}
+
+function buildJustifiedPanel( id, color, contentDirection ) {
+
+	const panel = new ThreeMeshUI.Block( {
+		width: contentDirection === 'row' ? DIM_HIGH : DIM_LOW,
+		height: contentDirection === 'row' ? DIM_LOW : DIM_HIGH,
+		contentDirection: contentDirection,
+		justifyContent: id,
+		backgroundOpacity: 0.5,
+		margin: 0.01
+	} );
+	container.add( panel );
+
+	const letters = 'ABCDEF';
+	for ( let i = 0; i < 5; i++ ) {
+		const blockText = new ThreeMeshUI.Block( {
+			width: 0.125,
+			height: 0.125,
+			margin: 0.01,
+			borderRadius: 0.02,
+			backgroundColor: color,
+			justifyContent: 'center',
+			alignContent: 'center'
+		} );
+		panel.add( blockText );
+
+		const text = new ThreeMeshUI.Text( {
+			content: letters[ i ]
+		} );
+		blockText.add( text );
+	}
+
+	return panel;
+}
+
+function makeTitlePanel(){
+	const panel = new ThreeMeshUI.Block( {
+		width: DIM_HIGH * 2,
+		height: 0.15,
+		contentDirection: 'row',
+		justifyContent: 'center',
+		backgroundOpacity: 0.2,
+		fontSize: 0.1,
+		fontFamily: FontJSON,
+		fontTexture: FontImage
+	} );
+
+
+	for ( let i = 0; i < justificationLegend.length; i++ ) {
+		const color = new THREE.Color( justificationLegend[ i ].color );
+		const id = justificationLegend[ i ].id;
+
+		// const textContainer = new ThreeMeshUI.Block({});
+		// panel.add( textContainer );
+
+		panel.add( new ThreeMeshUI.Text({
+			content : id,
+			fontColor : color
+		}) )
+
+	}
+
+	panel.scale.setScalar( 0.86 );
+	panel.position.set( 0, 1.8, -2.1 );
+
+	scene.add( panel );
+}
+// handles resizing the renderer when the viewport is resized
+
+function onWindowResize() {
+
+	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.updateProjectionMatrix();
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+}
+
+//
+let isInverted = false;
+setInterval( ()=>{
+	isInverted = !isInverted;
+
+	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
+		justifyInRow.children[ i ].set({contentDirection:isInverted?'row-reverse':'row'});
+	}
+
+	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
+		justifyInColumn.children[ i ].set({contentDirection:isInverted?'column-reverse':'column'});
+	}
+
+}, 2500 );
+
+let alignMode = 1;
+let aligns = ['start','center','end'];
+
+setInterval( ()=>{
+	alignMode += 1;
+	alignMode = alignMode >= aligns.length ? 0 : alignMode;
+
+	const mode = aligns[alignMode];
+	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
+		justifyInRow.children[ i ].set({alignContent:mode});
+	}
+
+	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
+		justifyInColumn.children[ i ].set({alignContent:mode});
+	}
+
+}, 1000 );
+
+
+let currentBigSize = DIM_HIGH;
+let currentSpeed = -0.005;
+
+function loop() {
+
+
+	currentBigSize += currentSpeed;
+	if( currentBigSize >= DIM_HIGH ){
+		currentBigSize = DIM_HIGH;
+		currentSpeed *= -1;
+	}else if( currentBigSize <= MIN_HIGH ){
+		currentBigSize = MIN_HIGH;
+		currentSpeed *= -1;
+	}
+
+	for ( let i = 1; i < justifyInRow.children.length; i++ ) {
+		justifyInRow.children[ i ].set({width:currentBigSize});
+	}
+
+	for ( let i = 1; i < justifyInColumn.children.length; i++ ) {
+		justifyInColumn.children[ i ].set({height:currentBigSize});
+	}
+
+
+	// Don't forget, ThreeMeshUI must be updated manually.
+	// This has been introduced in version 3.0.0 in order
+	// to improve performance
+	ThreeMeshUI.update();
+
+	controls.update();
+	renderer.render( scene, camera );
+
+	stats.update();
+
+}

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -159,11 +159,13 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 function makeTitlePanel(){
 
 	const panel = new ThreeMeshUI.Block( {
-		width: DIM_HIGH * 2,
+		width: DIM_HIGH * 1.85,
 		height: 0.15,
+		padding: 0.05,
 		contentDirection: 'row',
 		justifyContent: 'center',
-		backgroundOpacity: 0.2,
+		textAlign: 'justify',
+		backgroundOpacity: 0.6,
 		fontSize: 0.1,
 		fontFamily: FontJSON,
 		fontTexture: FontImage
@@ -176,7 +178,7 @@ function makeTitlePanel(){
 
 		panel.add(
 			new ThreeMeshUI.Text( {
-				content: id,
+				content: id + " ",
 				fontColor: color
 			} )
 		);

--- a/examples/justification.js
+++ b/examples/justification.js
@@ -124,7 +124,9 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 		contentDirection: contentDirection,
 		justifyContent: id,
 		backgroundOpacity: 0.5,
-		margin: 0.01
+		padding: 0.02,
+		margin: 0.01,
+		offset:0.0001
 	} );
 	container.add( panel );
 
@@ -139,7 +141,8 @@ function buildJustifiedPanel( id, color, contentDirection ) {
 			borderRadius: 0.02,
 			backgroundColor: color,
 			justifyContent: 'center',
-			alignItems: 'center'
+			alignItems: 'center',
+			offset:0.001
 		} );
 		panel.add( blockText );
 
@@ -214,7 +217,7 @@ setInterval( () => {
 }, 2500 );
 
 let alignMode = 1;
-const aligns = [ 'start', 'center', 'end' ];
+const aligns = [ 'start', 'center', 'end', 'stretch'];
 
 setInterval( () => {
 
@@ -267,6 +270,38 @@ setInterval( () => {
 	}
 
 }, 3000 );
+
+// let childAlignMode = 1;
+// const childAligns = [ 'center', 'stretch' ];
+//
+// setInterval( () => {
+//
+// 	childAlignMode += 1;
+// 	childAlignMode = childAlignMode >= childAligns.length ? 0 : childAlignMode;
+//
+// 	const mode = childAligns[ childAlignMode ];
+//
+// 	for ( let i = 1; i < justifyInRow.children.length; i ++ ) {
+//
+// 		for ( let j = 1; j < justifyInRow.children[ i ].children.length; j ++ ) {
+//
+// 			justifyInRow.children[ i ].children[ j ].set( { alignItems: mode } );
+//
+// 		}
+//
+// 	}
+//
+// 	for ( let i = 1; i < justifyInColumn.children.length; i ++ ) {
+//
+// 		for ( let j = 1; j < justifyInColumn.children[ i ].children.length; j ++ ) {
+//
+// 			justifyInColumn.children[ i ].children[ j ].set( { alignItems:mode } );
+//
+// 		}
+// 	}
+//
+// }, 500 );
+
 
 let currentBigSize = DIM_HIGH;
 let currentSpeed = - 0.005;

--- a/examples/letter_spacing.js
+++ b/examples/letter_spacing.js
@@ -62,7 +62,7 @@ function makeTextPanel() {
 		height: 0.5,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		fontFamily: FontJSON,
 		fontTexture: FontImage
 	} );

--- a/examples/manual_positioning.js
+++ b/examples/manual_positioning.js
@@ -89,7 +89,7 @@ function makeTextPanel() {
 		backgroundColor: new THREE.Color( 0xd9d9d9 ),
 		backgroundOpacity: 0.5,
 		justifyContent: 'end',
-		alignContent: 'right',
+		alignItems: 'end',
 		fontColor: new THREE.Color( 0x333333 ),
 		fontFamily: FontJSON,
 		fontTexture: FontImage

--- a/examples/msdf_text.js
+++ b/examples/msdf_text.js
@@ -83,7 +83,7 @@ function makeTextPanel() {
 		width: 1.5,
 		height: 1.2,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		backgroundOpacity: 0
 	} );
 

--- a/examples/nested_blocks.js
+++ b/examples/nested_blocks.js
@@ -96,14 +96,14 @@ function makeTextPanel() {
     width: 1.0,
     margin: 0.025,
     padding: 0.025,
-    alignContent: "left",
+    textAlign: "left",
     justifyContent: "end",
   });
 
   const caption = new ThreeMeshUI.Block({
     height: 0.07,
     width: 0.37,
-    alignContent: "center",
+    textAlign: "center",
     justifyContent: "center",
   });
 
@@ -151,8 +151,8 @@ function makeTextPanel() {
     margin: 0.01,
     padding: 0.02,
     fontSize: 0.025,
-    alignItems: "left",
-		textAlign: 'justify',
+    alignItems: "start",
+    textAlign: 'justify',
     backgroundOpacity: 0,
   }).add(
     new ThreeMeshUI.Text({

--- a/examples/nested_blocks.js
+++ b/examples/nested_blocks.js
@@ -151,7 +151,8 @@ function makeTextPanel() {
     margin: 0.01,
     padding: 0.02,
     fontSize: 0.025,
-    alignContent: "left",
+    alignItems: "left",
+		textAlign: 'justify',
     backgroundOpacity: 0,
   }).add(
     new ThreeMeshUI.Text({

--- a/examples/preloaded_font.js
+++ b/examples/preloaded_font.js
@@ -85,7 +85,7 @@ function makeTextPanel() {
 		height: 0.5,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignContent: 'left',
+		textAlign: 'left',
 		fontFamily: fontName,
 		fontTexture: fontName
 	} );

--- a/examples/text_align.js
+++ b/examples/text_align.js
@@ -113,7 +113,7 @@ function makeTextPanel(index,textAlign) {
 		new ThreeMeshUI.Text( {
 			content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
 			fontSize: 0.055
-		} ),
+		} )
 	);
 
 	group.position.set( -1.25 + index%3 * 1.25 , 1.85 + Math.floor(index / 3) * -0.9 , -2)

--- a/examples/text_align.js
+++ b/examples/text_align.js
@@ -36,7 +36,7 @@ function init() {
 	document.body.appendChild( renderer.domElement );
 
 	controls = new OrbitControls( camera, renderer.domElement );
-	camera.position.set( 0, 1.6, 0 );
+	camera.position.set( 0, 1.6, 0.75 );
 	controls.target = new THREE.Vector3( 0, 1.5, -1.8 );
 	controls.update();
 
@@ -50,11 +50,19 @@ function init() {
 	scene.add( room );
 
 	// TEXT PANEL
-	const textAligns = ["left","center","right", "justify-left", "justify", "justify-right"];
+	const textAligns = [
+		ThreeMeshUI.textAlign.LEFT, 					// 'left'
+		ThreeMeshUI.textAlign.CENTER, 				// 'center'
+		ThreeMeshUI.textAlign.RIGHT, 					// 'right'
+		ThreeMeshUI.textAlign.JUSTIFY_LEFT, 	// 'justify-left'
+		ThreeMeshUI.textAlign.JUSTIFY, 				// 'justify'
+		ThreeMeshUI.textAlign.JUSTIFY_RIGHT, 	// 'justify-right'
+		ThreeMeshUI.textAlign.JUSTIFY_CENTER 	// 'justify-center'
+	];
 
 	for ( let i = 0; i < textAligns.length; i++ ) {
 		const textAlign = textAligns[ i ];
-		makeTextPanel(i, textAlign);
+		makeTextPanel(i, textAlign, i=== textAligns.length-1);
 	}
 
 
@@ -66,25 +74,24 @@ function init() {
 
 //
 
-function makeTextPanel(index,textAlign) {
+function makeTextPanel(index,textAlign, last = false) {
 
 
 	const group = new Object3D();
 
 	const title = new ThreeMeshUI.Block( {
-		width: 1,
+		width: 1.15,
 		height: 0.15,
 		padding: 0.05,
 		backgroundColor: new THREE.Color(0xff9900),
 		justifyContent: 'center',
-		alignContent: 'center',
 		fontFamily: FontJSON,
 		fontTexture: FontImage
 	} );
 
 	const titleText = new ThreeMeshUI.Text( {
-			content: 'textAlign: "'+textAlign+'"',
-			fontSize: 0.08
+			content: '.set({textAlign: "'+textAlign+'"})',
+			fontSize: 0.075
 		} );
 
 	title.add(
@@ -94,11 +101,11 @@ function makeTextPanel(index,textAlign) {
 	group.add( title );
 
 	const container = new ThreeMeshUI.Block( {
-		width: 1.2,
+		width: 1.3,
 		height: 0.5,
 		padding: 0.05,
 		justifyContent: 'center',
-		alignItems: 'left',
+		alignItems: 'start',
 		textAlign,
 		fontFamily: FontJSON,
 		fontTexture: FontImage
@@ -116,7 +123,14 @@ function makeTextPanel(index,textAlign) {
 		} )
 	);
 
-	group.position.set( -1.25 + index%3 * 1.25 , 1.85 + Math.floor(index / 3) * -0.9 , -2)
+	group.position.set( -1.35 + index%3 * 1.35 , 2.25 + Math.floor(index / 3) * -0.8 , -2);
+
+	if( last ){
+
+		group.position.x = 0;
+
+	}
+
 	scene.add( group );
 
 }

--- a/examples/text_align.js
+++ b/examples/text_align.js
@@ -1,0 +1,146 @@
+import * as THREE from 'three';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BoxLineGeometry } from 'three/examples/jsm/geometries/BoxLineGeometry.js';
+
+import ThreeMeshUI from '../src/three-mesh-ui.js';
+
+import FontJSON from './assets/Roboto-msdf.json';
+import FontImage from './assets/Roboto-msdf.png';
+import { Object3D } from 'three';
+
+const WIDTH = window.innerWidth;
+const HEIGHT = window.innerHeight;
+
+let scene, camera, renderer, controls;
+
+window.addEventListener( 'load', init );
+window.addEventListener( 'resize', onWindowResize );
+
+//
+
+function init() {
+
+	scene = new THREE.Scene();
+	scene.background = new THREE.Color( 0x505050 );
+
+	camera = new THREE.PerspectiveCamera( 60, WIDTH / HEIGHT, 0.1, 100 );
+
+	renderer = new THREE.WebGLRenderer( {
+		antialias: true
+	} );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( WIDTH, HEIGHT );
+	renderer.xr.enabled = true;
+	document.body.appendChild( VRButton.createButton( renderer ) );
+	document.body.appendChild( renderer.domElement );
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	camera.position.set( 0, 1.6, 0 );
+	controls.target = new THREE.Vector3( 0, 1.5, -1.8 );
+	controls.update();
+
+	// ROOM
+
+	const room = new THREE.LineSegments(
+		new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ).translate( 0, 3, 0 ),
+		new THREE.LineBasicMaterial( { color: 0x808080 } )
+	);
+
+	scene.add( room );
+
+	// TEXT PANEL
+	const textAligns = ["left","center","right", "justify-left", "justify", "justify-right"];
+
+	for ( let i = 0; i < textAligns.length; i++ ) {
+		const textAlign = textAligns[ i ];
+		makeTextPanel(i, textAlign);
+	}
+
+
+	//
+
+	renderer.setAnimationLoop( loop );
+
+}
+
+//
+
+function makeTextPanel(index,textAlign) {
+
+
+	const group = new Object3D();
+
+	const title = new ThreeMeshUI.Block( {
+		width: 1,
+		height: 0.15,
+		padding: 0.05,
+		backgroundColor: new THREE.Color(0xff9900),
+		justifyContent: 'center',
+		alignContent: 'center',
+		fontFamily: FontJSON,
+		fontTexture: FontImage
+	} );
+
+	const titleText = new ThreeMeshUI.Text( {
+			content: 'textAlign: "'+textAlign+'"',
+			fontSize: 0.08
+		} );
+
+	title.add(
+		titleText
+	);
+	title.position.set( 0, 0.35, 0 );
+	group.add( title );
+
+	const container = new ThreeMeshUI.Block( {
+		width: 1.2,
+		height: 0.5,
+		padding: 0.05,
+		justifyContent: 'center',
+		alignItems: 'left',
+		textAlign,
+		fontFamily: FontJSON,
+		fontTexture: FontImage
+	} );
+
+	// container.rotation.x = -0.25;
+	group.add( container );
+
+	//
+
+	container.add(
+		new ThreeMeshUI.Text( {
+			content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+			fontSize: 0.055
+		} ),
+	);
+
+	group.position.set( -1.25 + index%3 * 1.25 , 1.85 + Math.floor(index / 3) * -0.9 , -2)
+	scene.add( group );
+
+}
+
+// handles resizing the renderer when the viewport is resized
+
+function onWindowResize() {
+
+	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.updateProjectionMatrix();
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+}
+
+//
+
+function loop() {
+
+	// Don't forget, ThreeMeshUI must be updated manually.
+	// This has been introduced in version 3.0.0 in order
+	// to improve performance
+	ThreeMeshUI.update();
+
+	controls.update();
+	renderer.render( scene, camera );
+
+}

--- a/examples/tutorial_result.js
+++ b/examples/tutorial_result.js
@@ -115,7 +115,7 @@ function makeUI() {
   });
 
   textBlock.set({
-    alignContent: "right",
+    textAlign: "right",
     justifyContent: "end",
     padding: 0.03,
   });

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -398,8 +398,6 @@ export default function BoxComponent( Base ) {
 
 			}
 
-			warnAboutDeprecatedAlignItems();
-
 			this.children.forEach( ( child ) => {
 
 				if ( !child.isBoxComponent ) return;
@@ -433,8 +431,6 @@ export default function BoxComponent( Base ) {
 				console.warn( `alignItems === '${ALIGNMENT}' is not supported` );
 
 			}
-
-			warnAboutDeprecatedAlignItems();
 
 
 			this.children.forEach( ( child ) => {
@@ -489,7 +485,7 @@ export default function BoxComponent( Base ) {
 
 			// This is for stretch alignment
 			// @TODO : Conceive a better performant way
-			if( this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
+			if( this.parent && this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
 
 				if( this.parent.getContentDirection().indexOf('column') !== -1 ){
 
@@ -512,7 +508,7 @@ export default function BoxComponent( Base ) {
 
 			// This is for stretch alignment
 			// @TODO : Conceive a better performant way
-			if( this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
+			if( this.parent && this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
 
 				if( this.parent.getContentDirection().indexOf('row') !== -1 ){
 
@@ -546,30 +542,9 @@ const AVAILABLE_ALIGN_ITEMS = [
 	'end',
 	'stretch',
 	'top', // @TODO: Be remove upon 7.x.x
-	'bottom' // @TODO: Be remove upon 7.x.x
+	'right', // @TODO: Be remove upon 7.x.x
+	'bottom', // @TODO: Be remove upon 7.x.x
+	'left' // @TODO: Be remove upon 7.x.x
 ];
-
-// @TODO: Be remove upon 7.x.x
-const DEPRECATED_ALIGN_ITEMS = [
-	'top',
-	'right',
-	'bottom',
-	'left'
-]
-
-/**
- * @deprecated
- * // @TODO: Be remove upon 7.x.x
- * @param alignment
- */
-function warnAboutDeprecatedAlignItems( alignment ){
-
-	if( DEPRECATED_ALIGN_ITEMS.indexOf(alignment) !== - 1){
-
-		console.warn(`alignItems === '${alignment}' is deprecated and will be remove in 7.x.x. Fallback are 'start'|'end'`)
-
-	}
-
-}
 
 const _boxChildrenFilter = c => c.isBoxComponent;

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -165,13 +165,20 @@ export default function BoxComponent( Base ) {
 
 			const JUSTIFICATION = this.getJustifyContent();
 
-			const availableJustification = ['start','center','end','space-around','space-between','space-evenly'];
-			if( availableJustification.indexOf(JUSTIFICATION) === -1 ){
+			const availableJustification = [
+				'start',
+				'center',
+				'end',
+				'space-around',
+				'space-between',
+				'space-evenly'
+			];
 
-				console.warn( `justifyContent === '${JUSTIFICATION}' is not supported` );
+			if ( availableJustification.indexOf( JUSTIFICATION ) === -1 ) {
+
+				console.warn( `justifyContent === '${ JUSTIFICATION }' is not supported` );
 
 			}
-
 
 			// only work on boxChildren
 			const boxChildren = this.children.filter( c => c.isBoxComponent );
@@ -211,7 +218,7 @@ export default function BoxComponent( Base ) {
 
 				case "center":
 					justificationOffset = axisOffset / 2;
-				break;
+					break;
 
 				// stays with an offset of 0
 				case "space-between":
@@ -222,9 +229,9 @@ export default function BoxComponent( Base ) {
 
 			}
 
-			let justificationMargins = boxChildren.map( c => 0 );
+			const justificationMargins = Array( boxChildren.length ).fill( 0 );
 
-			if( remainingSpace > 0 ) {
+			if ( remainingSpace > 0 ) {
 
 				switch ( JUSTIFICATION ) {
 
@@ -269,7 +276,7 @@ export default function BoxComponent( Base ) {
 						// only one children would act as start
 						if ( boxChildren.length > 1 ) {
 
-							let margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
+							const margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
 
 							const start = margin / 2;
 							justificationMargins[ 0 ] = start;
@@ -308,10 +315,18 @@ export default function BoxComponent( Base ) {
 
 			const JUSTIFICATION = this.getJustifyContent();
 
-			const availableJustification = ['start','center','end','space-around','space-between','space-evenly'];
-			if( availableJustification.indexOf(JUSTIFICATION) === -1 ){
+			const availableJustification = [
+				'start',
+				'center',
+				'end',
+				'space-around',
+				'space-between',
+				'space-evenly'
+			];
 
-				console.warn( `justifyContent === '${JUSTIFICATION}' is not supported` );
+			if ( availableJustification.indexOf(JUSTIFICATION) === -1 ){
+
+				console.warn( `justifyContent === '${ JUSTIFICATION }' is not supported` );
 
 			}
 
@@ -363,8 +378,9 @@ export default function BoxComponent( Base ) {
 
 			}
 
-			let justificationMargins = boxChildren.map( c => 0);
-			if( remainingSpace > 0 ) {
+			const justificationMargins = Array( boxChildren.length ).fill( 0 );
+
+			if ( remainingSpace > 0 ) {
 
 				switch ( JUSTIFICATION ) {
 
@@ -409,7 +425,7 @@ export default function BoxComponent( Base ) {
 						// only one children would act as start
 						if ( boxChildren.length > 1 ) {
 
-							let margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
+							const margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
 
 							const start = margin / 2;
 							justificationMargins[ 0 ] = start;

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -389,7 +389,7 @@ export default function BoxComponent( Base ) {
 		/** called if justifyContent is 'column' or 'column-reverse', it align the content horizontally */
 		alignChildrenOnX() {
 
-			const ALIGNMENT = this.getAlignContent();
+			const ALIGNMENT = this.getAlignItems();
 			const X_TARGET = ( this.getWidth() / 2 ) - ( this.padding || 0 );
 
 			const availableAlignments = ['start','center','end','left','right'];
@@ -398,6 +398,8 @@ export default function BoxComponent( Base ) {
 				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
 
 			}
+
+			warnAboutDeprecatedAlignItems();
 
 			this.children.forEach( ( child ) => {
 
@@ -424,7 +426,7 @@ export default function BoxComponent( Base ) {
 		/** called if justifyContent is 'row' or 'row-reverse', it align the content vertically */
 		alignChildrenOnY() {
 
-			const ALIGNMENT = this.getAlignContent();
+			const ALIGNMENT = this.getAlignItems();
 			const Y_TARGET = ( this.getHeight() / 2 ) - ( this.padding || 0 );
 
 			const availableAlignments = ['start','center','end','top','bottom'];
@@ -433,6 +435,9 @@ export default function BoxComponent( Base ) {
 				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
 
 			}
+
+			warnAboutDeprecatedAlignItems();
+
 
 			this.children.forEach( ( child ) => {
 
@@ -510,5 +515,26 @@ const AVAILABLE_JUSTIFICATIONS = [
 	'space-between',
 	'space-evenly'
 ];
+
+const DEPRECATED_ALIGN_ITEMS = [
+	'top',
+	'right',
+	'bottom',
+	'left'
+]
+
+/**
+ * @deprecated
+ * @param alignment
+ */
+function warnAboutDeprecatedAlignItems( alignment ){
+
+	if( DEPRECATED_ALIGN_ITEMS.indexOf(alignment) !== - 1){
+
+		console.warn(`alignItems === '${alignment}' is deprecated and will be remove in 7.x.x. Fallback are 'start'|'end'`)
+
+	}
+
+}
 
 const _boxChildrenFilter = c => c.isBoxComponent;

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -165,13 +165,18 @@ export default function BoxComponent( Base ) {
 
 			const JUSTIFICATION = this.getJustifyContent();
 
-			if ( JUSTIFICATION !== 'center' && JUSTIFICATION !== 'start' && JUSTIFICATION !== 'end' ) {
-				console.warn( `justifiyContent === '${JUSTIFICATION}' is not supported` );
+			const availableJustification = ['start','center','end','space-around','space-between','space-evenly'];
+			if( availableJustification.indexOf(JUSTIFICATION) === -1 ){
+
+				console.warn( `justifyContent === '${JUSTIFICATION}' is not supported` );
+
 			}
 
-			this.children.reduce( ( accu, child ) => {
 
-				if ( !child.isBoxComponent ) return accu;
+			// only work on boxChildren
+			const boxChildren = this.children.filter( c => c.isBoxComponent );
+
+			boxChildren.reduce( ( accu, child ) => {
 
 				const CHILD_ID = child.id;
 				const CHILD_WIDTH = child.getWidth();
@@ -190,21 +195,113 @@ export default function BoxComponent( Base ) {
 
 			//
 
-			if ( JUSTIFICATION === 'end' || JUSTIFICATION === 'center' ) {
+			const usedWidth = this.getChildrenSideSum( 'width' );
+			const innerWidth = this.getInnerWidth();
 
-				let offset = ( startPos * 2 ) - ( this.getChildrenSideSum( 'width' ) * Math.sign( startPos ) );
+			const remainingSpace = innerWidth - usedWidth;
 
-				if ( JUSTIFICATION === 'center' ) offset /= 2;
+			const axisOffset = ( startPos * 2 ) - ( this.getChildrenSideSum( 'width' ) * Math.sign( startPos ) );
+			let justificationOffset = 0;
 
-				this.children.forEach( ( child ) => {
+			switch ( JUSTIFICATION ){
 
-					if ( !child.isBoxComponent ) return;
+				case "end":
+					justificationOffset = axisOffset;
+					break;
 
-					this.childrenPos[ child.id ].x -= offset;
+				case "center":
+					justificationOffset = axisOffset / 2;
+				break;
 
-				} );
+				// stays with an offset of 0
+				case "space-between":
+				case "space-around":
+				case "space-evenly":
+				case "start":
+				default:
 
 			}
+
+			let justificationMargins = [];
+			switch ( JUSTIFICATION ){
+
+				case "space-between":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						const margin = remainingSpace / (boxChildren.length-1) * -Math.sign( startPos );
+						// set this margin for any children
+
+						// except for first child
+						justificationMargins[0] = 0;
+
+						for ( let i = 1; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = margin*i;
+
+						}
+
+					}
+
+					break;
+
+				case "space-evenly":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						const margin = remainingSpace / (boxChildren.length+1) * -Math.sign( startPos );
+
+						// set this margin for any children
+						for ( let i = 0; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = margin * ( i + 1 );
+
+						}
+
+					}
+
+					break;
+
+				case "space-around":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						let margin = remainingSpace / (boxChildren.length) * -Math.sign( startPos );
+
+						const start = margin / 2;
+						justificationMargins[0] = start;
+
+						// set this margin for any children
+						for ( let i = 1; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = start + margin * i;
+
+						}
+
+					}
+
+					break;
+
+				// those cases doesn't involve additional margins
+				case "end":
+				case "center":
+				case "start":
+				default:
+
+					for ( let i = 0; i < boxChildren.length; i++ ) {
+
+						justificationMargins[i] = 0;
+
+					}
+
+			}
+
+			// Apply
+			boxChildren.forEach( ( child , childIndex ) => {
+
+				this.childrenPos[ child.id ].x -= justificationOffset - justificationMargins[childIndex];
+
+			} );
 
 		}
 
@@ -213,9 +310,16 @@ export default function BoxComponent( Base ) {
 
 			const JUSTIFICATION = this.getJustifyContent();
 
-			this.children.reduce( ( accu, child ) => {
+			const availableJustification = ['start','center','end','space-around','space-between','space-evenly'];
+			if( availableJustification.indexOf(JUSTIFICATION) === -1 ){
 
-				if ( !child.isBoxComponent ) return accu;
+				console.warn( `justifyContent === '${JUSTIFICATION}' is not supported` );
+
+			}
+
+			// only work on boxChildren
+			const boxChildren = this.children.filter( c => c.isBoxComponent );
+			boxChildren.reduce( ( accu, child ) => {
 
 				const CHILD_ID = child.id;
 				const CHILD_HEIGHT = child.getHeight();
@@ -234,21 +338,112 @@ export default function BoxComponent( Base ) {
 
 			//
 
-			if ( JUSTIFICATION === 'end' || JUSTIFICATION === 'center' ) {
+			const usedWidth = this.getChildrenSideSum( 'height' );
+			const innerWidth = this.getInnerHeight();
 
-				let offset = ( startPos * 2 ) - ( this.getChildrenSideSum( 'height' ) * Math.sign( startPos ) );
+			const remainingSpace = innerWidth - usedWidth;
 
-				if ( JUSTIFICATION === 'center' ) offset /= 2;
+			const axisOffset = ( startPos * 2 ) - ( this.getChildrenSideSum( 'height' ) * Math.sign( startPos ) );
+			let justificationOffset = 0;
 
-				this.children.forEach( ( child ) => {
+			switch ( JUSTIFICATION ){
 
-					if ( !child.isBoxComponent ) return;
+				case "end":
+					justificationOffset = axisOffset;
+					break;
 
-					this.childrenPos[ child.id ].y -= offset;
+				case "center":
+					justificationOffset = axisOffset / 2;
+					break;
 
-				} );
+				// stays with an offset of 0
+				case "space-between":
+				case "space-around":
+				case "space-evenly":
+				case "start":
+				default:
 
 			}
+
+			let justificationMargins = [];
+			switch ( JUSTIFICATION ){
+
+				case "space-between":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						const margin = remainingSpace / (boxChildren.length-1) * -Math.sign( startPos );
+						// set this margin for any children
+
+						// except for first child
+						justificationMargins[0] = 0;
+
+						for ( let i = 1; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = margin*i;
+
+						}
+
+					}
+
+					break;
+
+				case "space-evenly":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						const margin = remainingSpace / (boxChildren.length+1) * -Math.sign( startPos );
+
+						// set this margin for any children
+						for ( let i = 0; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = margin * ( i + 1 );
+
+						}
+
+					}
+
+					break;
+
+				case "space-around":
+					// only one children would act as start
+					if( boxChildren.length > 1 ){
+
+						let margin = remainingSpace / (boxChildren.length) * -Math.sign( startPos );
+
+						const start = margin / 2;
+						justificationMargins[0] = start;
+
+						// set this margin for any children
+						for ( let i = 1; i < boxChildren.length; i++ ) {
+
+							justificationMargins[i] = start + margin * i;
+
+						}
+
+					}
+
+					break;
+
+				// those cases doesn't involve additional margins
+				case "end":
+				case "center":
+				case "start":
+				default:
+
+					for ( let i = 0; i < boxChildren.length; i++ ) {
+
+						justificationMargins[i] = 0;
+
+					}
+
+			}
+
+			boxChildren.forEach( ( child, childIndex ) => {
+
+				this.childrenPos[ child.id ].y -= justificationOffset - justificationMargins[childIndex];
+
+			} );
 
 		}
 
@@ -258,8 +453,11 @@ export default function BoxComponent( Base ) {
 			const ALIGNMENT = this.getAlignContent();
 			const X_TARGET = ( this.getWidth() / 2 ) - ( this.padding || 0 );
 
-			if ( ALIGNMENT !== 'center' && ALIGNMENT !== 'right' && ALIGNMENT !== 'left' ) {
-				console.warn( `alignContent === '${ALIGNMENT}' is not supported on this direction.` );
+			const availableAlignments = ['start','center','end','left','right'];
+			if( availableAlignments.indexOf(ALIGNMENT) === -1 ){
+
+				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
+
 			}
 
 			this.children.forEach( ( child ) => {
@@ -268,11 +466,11 @@ export default function BoxComponent( Base ) {
 
 				let offset;
 
-				if ( ALIGNMENT === 'right' ) {
+				if ( ALIGNMENT === 'right' || ALIGNMENT === 'end' ) {
 
 					offset = X_TARGET - ( child.getWidth() / 2 ) - ( child.margin || 0 );
 
-				} else if ( ALIGNMENT === 'left' ) {
+				} else if ( ALIGNMENT === 'left' || ALIGNMENT === 'start' ) {
 
 					offset = -X_TARGET + ( child.getWidth() / 2 ) + ( child.margin || 0 );
 
@@ -290,8 +488,11 @@ export default function BoxComponent( Base ) {
 			const ALIGNMENT = this.getAlignContent();
 			const Y_TARGET = ( this.getHeight() / 2 ) - ( this.padding || 0 );
 
-			if ( ALIGNMENT !== 'center' && ALIGNMENT !== 'top' && ALIGNMENT !== 'bottom' ) {
-				console.warn( `alignContent === '${ALIGNMENT}' is not supported on this direction.` );
+			const availableAlignments = ['start','center','end','top','bottom'];
+			if( availableAlignments.indexOf(ALIGNMENT) === -1 ){
+
+				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
+
 			}
 
 			this.children.forEach( ( child ) => {
@@ -300,11 +501,11 @@ export default function BoxComponent( Base ) {
 
 				let offset;
 
-				if ( ALIGNMENT === 'top' ) {
+				if ( ALIGNMENT === 'top' || ALIGNMENT === 'start' ) {
 
 					offset = Y_TARGET - ( child.getHeight() / 2 ) - ( child.margin || 0 );
 
-				} else if ( ALIGNMENT === 'bottom' ) {
+				} else if ( ALIGNMENT === 'bottom' || ALIGNMENT === 'end' ) {
 
 					offset = -Y_TARGET + ( child.getHeight() / 2 ) + ( child.margin || 0 );
 

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -392,10 +392,9 @@ export default function BoxComponent( Base ) {
 			const ALIGNMENT = this.getAlignItems();
 			const X_TARGET = ( this.getWidth() / 2 ) - ( this.padding || 0 );
 
-			const availableAlignments = ['start','center','end','left','right'];
-			if( availableAlignments.indexOf(ALIGNMENT) === -1 ){
+			if( AVAILABLE_ALIGN_ITEMS.indexOf(ALIGNMENT) === -1 ){
 
-				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
+				console.warn( `alignItems === '${ALIGNMENT}' is not supported` );
 
 			}
 
@@ -429,10 +428,9 @@ export default function BoxComponent( Base ) {
 			const ALIGNMENT = this.getAlignItems();
 			const Y_TARGET = ( this.getHeight() / 2 ) - ( this.padding || 0 );
 
-			const availableAlignments = ['start','center','end','top','bottom'];
-			if( availableAlignments.indexOf(ALIGNMENT) === -1 ){
+			if( AVAILABLE_ALIGN_ITEMS.indexOf(ALIGNMENT) === -1 ){
 
-				console.warn( `alignContent === '${ALIGNMENT}' is not supported` );
+				console.warn( `alignItems === '${ALIGNMENT}' is not supported` );
 
 			}
 
@@ -488,6 +486,20 @@ export default function BoxComponent( Base ) {
 		 */
 		getWidth() {
 
+
+			// This is for stretch alignment
+			// @TODO : Conceive a better performant way
+			if( this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
+
+				if( this.parent.getContentDirection().indexOf('column') !== -1 ){
+
+					return this.parent.getWidth() -  ( this.parent.padding * 2 || 0 );
+
+				}
+
+			}
+
+
 			return this.width || this.getInnerWidth() + ( this.padding * 2 || 0 );
 
 		}
@@ -497,6 +509,18 @@ export default function BoxComponent( Base ) {
 		 * With padding, without margin
 		 */
 		getHeight() {
+
+			// This is for stretch alignment
+			// @TODO : Conceive a better performant way
+			if( this.parent.isUI && this.parent.getAlignItems() === 'stretch' ){
+
+				if( this.parent.getContentDirection().indexOf('row') !== -1 ){
+
+					return this.parent.getHeight() - ( this.parent.padding * 2 || 0 );
+
+				}
+
+			}
 
 			return this.height || this.getInnerHeight() + ( this.padding * 2 || 0 );
 
@@ -516,6 +540,16 @@ const AVAILABLE_JUSTIFICATIONS = [
 	'space-evenly'
 ];
 
+const AVAILABLE_ALIGN_ITEMS = [
+	'start',
+	'center',
+	'end',
+	'stretch',
+	'top', // @TODO: Be remove upon 7.x.x
+	'bottom' // @TODO: Be remove upon 7.x.x
+];
+
+// @TODO: Be remove upon 7.x.x
 const DEPRECATED_ALIGN_ITEMS = [
 	'top',
 	'right',
@@ -525,6 +559,7 @@ const DEPRECATED_ALIGN_ITEMS = [
 
 /**
  * @deprecated
+ * // @TODO: Be remove upon 7.x.x
  * @param alignment
  */
 function warnAboutDeprecatedAlignItems( alignment ){

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -222,77 +222,75 @@ export default function BoxComponent( Base ) {
 
 			}
 
-			let justificationMargins = [];
-			switch ( JUSTIFICATION ){
+			let justificationMargins = boxChildren.map( c => 0 );
 
-				case "space-between":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
+			if( remainingSpace > 0 ) {
 
-						const margin = remainingSpace / (boxChildren.length-1) * -Math.sign( startPos );
-						// set this margin for any children
+				switch ( JUSTIFICATION ) {
 
-						// except for first child
-						justificationMargins[0] = 0;
+					case "space-between":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-						for ( let i = 1; i < boxChildren.length; i++ ) {
+							const margin = remainingSpace / ( boxChildren.length - 1 ) * -Math.sign( startPos );
+							// set this margin for any children
 
-							justificationMargins[i] = margin*i;
+							// except for first child
+							justificationMargins[ 0 ] = 0;
 
-						}
+							for ( let i = 1; i < boxChildren.length; i++ ) {
 
-					}
+								justificationMargins[ i ] = margin * i;
 
-					break;
-
-				case "space-evenly":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
-
-						const margin = remainingSpace / (boxChildren.length+1) * -Math.sign( startPos );
-
-						// set this margin for any children
-						for ( let i = 0; i < boxChildren.length; i++ ) {
-
-							justificationMargins[i] = margin * ( i + 1 );
+							}
 
 						}
 
-					}
+						break;
 
-					break;
+					case "space-evenly":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-				case "space-around":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
+							const margin = remainingSpace / ( boxChildren.length + 1 ) * -Math.sign( startPos );
 
-						let margin = remainingSpace / (boxChildren.length) * -Math.sign( startPos );
+							// set this margin for any children
+							for ( let i = 0; i < boxChildren.length; i++ ) {
 
-						const start = margin / 2;
-						justificationMargins[0] = start;
+								justificationMargins[ i ] = margin * ( i + 1 );
 
-						// set this margin for any children
-						for ( let i = 1; i < boxChildren.length; i++ ) {
-
-							justificationMargins[i] = start + margin * i;
+							}
 
 						}
 
-					}
+						break;
 
-					break;
+					case "space-around":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-				// those cases doesn't involve additional margins
-				case "end":
-				case "center":
-				case "start":
-				default:
+							let margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
 
-					for ( let i = 0; i < boxChildren.length; i++ ) {
+							const start = margin / 2;
+							justificationMargins[ 0 ] = start;
 
-						justificationMargins[i] = 0;
+							// set this margin for any children
+							for ( let i = 1; i < boxChildren.length; i++ ) {
 
-					}
+								justificationMargins[ i ] = start + margin * i;
+
+							}
+
+						}
+
+						break;
+
+					// those cases doesn't involve additional margins
+					case "end":
+					case "center":
+					case "start":
+
+				}
 
 			}
 
@@ -365,78 +363,75 @@ export default function BoxComponent( Base ) {
 
 			}
 
-			let justificationMargins = [];
-			switch ( JUSTIFICATION ){
+			let justificationMargins = boxChildren.map( c => 0);
+			if( remainingSpace > 0 ) {
 
-				case "space-between":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
+				switch ( JUSTIFICATION ) {
 
-						const margin = remainingSpace / (boxChildren.length-1) * -Math.sign( startPos );
-						// set this margin for any children
+					case "space-between":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-						// except for first child
-						justificationMargins[0] = 0;
+							const margin = remainingSpace / ( boxChildren.length - 1 ) * -Math.sign( startPos );
+							// set this margin for any children
 
-						for ( let i = 1; i < boxChildren.length; i++ ) {
+							// except for first child
+							justificationMargins[ 0 ] = 0;
 
-							justificationMargins[i] = margin*i;
+							for ( let i = 1; i < boxChildren.length; i++ ) {
 
-						}
+								justificationMargins[ i ] = margin * i;
 
-					}
-
-					break;
-
-				case "space-evenly":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
-
-						const margin = remainingSpace / (boxChildren.length+1) * -Math.sign( startPos );
-
-						// set this margin for any children
-						for ( let i = 0; i < boxChildren.length; i++ ) {
-
-							justificationMargins[i] = margin * ( i + 1 );
+							}
 
 						}
 
-					}
+						break;
 
-					break;
+					case "space-evenly":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-				case "space-around":
-					// only one children would act as start
-					if( boxChildren.length > 1 ){
+							const margin = remainingSpace / ( boxChildren.length + 1 ) * -Math.sign( startPos );
 
-						let margin = remainingSpace / (boxChildren.length) * -Math.sign( startPos );
+							// set this margin for any children
+							for ( let i = 0; i < boxChildren.length; i++ ) {
 
-						const start = margin / 2;
-						justificationMargins[0] = start;
+								justificationMargins[ i ] = margin * ( i + 1 );
 
-						// set this margin for any children
-						for ( let i = 1; i < boxChildren.length; i++ ) {
-
-							justificationMargins[i] = start + margin * i;
+							}
 
 						}
 
-					}
+						break;
 
-					break;
+					case "space-around":
+						// only one children would act as start
+						if ( boxChildren.length > 1 ) {
 
-				// those cases doesn't involve additional margins
-				case "end":
-				case "center":
-				case "start":
-				default:
+							let margin = remainingSpace / ( boxChildren.length ) * -Math.sign( startPos );
 
-					for ( let i = 0; i < boxChildren.length; i++ ) {
+							const start = margin / 2;
+							justificationMargins[ 0 ] = start;
 
-						justificationMargins[i] = 0;
+							// set this margin for any children
+							for ( let i = 1; i < boxChildren.length; i++ ) {
 
-					}
+								justificationMargins[ i ] = start + margin * i;
 
+							}
+
+						}
+
+						break;
+
+					// those cases doesn't involve additional margins
+					case "end":
+					case "center":
+					case "start":
+					default:
+
+				}
 			}
 
 			boxChildren.forEach( ( child, childIndex ) => {

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -29,6 +29,7 @@ export default function InlineManager( Base ) {
 			// got by MeshUIComponent
 			const JUSTIFICATION = this.getJustifyContent();
 			const ALIGNMENT = this.getAlignContent();
+
 			const INTERLINE = this.getInterLine();
 
 			// Compute lines
@@ -98,11 +99,20 @@ export default function InlineManager( Base ) {
 					switch ( ALIGNMENT ) {
 
 						case 'left':
+							console.warn(`alignContent 'left' has been deprecated. Please rely on 'start' or 'end' instead`);
+							// fallthrough
+						case 'start':
 							return -INNER_WIDTH / 2;
+
 						case 'right':
+							console.warn(`alignContent 'left' has been deprecated. Please rely on 'start' or 'end' instead`);
+							// fallthrough
+						case 'end':
 							return -line.width + ( INNER_WIDTH / 2 );
+
 						case 'center':
 							return -line.width / 2;
+
 						default:
 							console.warn( `alignContent: '${ALIGNMENT}' is not valid` );
 

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -15,6 +15,8 @@ in its own updateLayout function.
  */
 import Whitespace from '../../utils/Whitespace';
 
+import * as TextAlign from '../../utils/TextAlign';
+
 export default function InlineManager( Base ) {
 
 	return class InlineManager extends Base {
@@ -91,87 +93,7 @@ export default function InlineManager( Base ) {
 			} );
 
 			// Horizontal positioning
-
-			lines.forEach( ( line, i ) => {
-
-				const alignmentOffset = ( () => {
-
-					switch ( ALIGNMENT ) {
-
-						case 'justify-left':
-							// fallthrough
-						case 'justify':
-							// fallthrough
-						case 'left':
-							// fallthrough
-						case 'start':
-							return -INNER_WIDTH / 2;
-
-						case 'justify-right':
-							// fallthrough
-						case 'right':
-							// fallthrough
-						case 'end':
-							return -line.width + ( INNER_WIDTH / 2 );
-
-						case 'center':
-							return -line.width / 2;
-
-						default:
-							console.warn( `textAlign: '${ALIGNMENT}' is not valid` );
-
-					}
-				} )();
-
-				line.forEach( ( char ) => {
-
-					char.offsetX += alignmentOffset;
-
-				} );
-
-
-				// justification
-				if( ALIGNMENT.indexOf('justify') === 0 ){
-
-					// do not process last line for justify-left or justify-right
-					if( ALIGNMENT.indexOf('-') !== -1 && i === lines.length - 1 ) return;
-
-					// can only justify is space is remaining
-					const REMAINING_SPACE = INNER_WIDTH - line.width;
-					if( REMAINING_SPACE <= 0 ) return;
-
-					// count the valid spaces to extend
-					// Do not take the first nor the last space into account
-					let validSpaces = 0;
-					for ( let j = 1; j < line.length - 1; j++ ) {
-
-						validSpaces += line[ j ].glyph === ' ' ? 1 : 0;
-
-					}
-					const additionalSpace = REMAINING_SPACE / validSpaces;
-
-					let offsetX = 0;
-					if( ALIGNMENT === 'justify' || ALIGNMENT === 'justify-left' ){
-
-						for ( let j = 1 ; j <= line.length - 1; j++ ) {
-							const char = line[ j ];
-							char.offsetX += offsetX;
-							offsetX += char.glyph === ' ' ? additionalSpace : 0;
-						}
-					}
-					else {
-
-						for ( let j = line.length - 2; j >= 0; j-- ) {
-							const char = line[ j ];
-							char.offsetX -= offsetX;
-							offsetX += char.glyph === ' ' ? additionalSpace : 0;
-						}
-
-					}
-
-				}
-
-			} );
+			TextAlign.alignLines( lines, ALIGNMENT, INNER_WIDTH );
 
 		}
 

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -92,17 +92,23 @@ export default function InlineManager( Base ) {
 
 			// Horizontal positioning
 
-			lines.forEach( ( line, i, arr ) => {
+			lines.forEach( ( line, i ) => {
 
 				const alignmentOffset = ( () => {
 
 					switch ( ALIGNMENT ) {
 
+						case 'justify-left':
+							// fallthrough
+						case 'justify':
+							// fallthrough
 						case 'left':
 							// fallthrough
 						case 'start':
 							return -INNER_WIDTH / 2;
 
+						case 'justify-right':
+							// fallthrough
 						case 'right':
 							// fallthrough
 						case 'end':
@@ -112,7 +118,7 @@ export default function InlineManager( Base ) {
 							return -line.width / 2;
 
 						default:
-							console.warn( `alignContent: '${ALIGNMENT}' is not valid` );
+							console.warn( `textAlign: '${ALIGNMENT}' is not valid` );
 
 					}
 				} )();
@@ -122,6 +128,48 @@ export default function InlineManager( Base ) {
 					char.offsetX += alignmentOffset;
 
 				} );
+
+
+				// justification
+				if( ALIGNMENT.indexOf('justify') === 0 ){
+
+					// do not process last line for justify-left or justify-right
+					if( ALIGNMENT.indexOf('-') !== -1 && i === lines.length - 1 ) return;
+
+					// can only justify is space is remaining
+					const REMAINING_SPACE = INNER_WIDTH - line.width;
+					if( REMAINING_SPACE <= 0 ) return;
+
+					// count the valid spaces to extend
+					// Do not take the first nor the last space into account
+					let validSpaces = 0;
+					for ( let j = 1; j < line.length - 1; j++ ) {
+
+						validSpaces += line[ j ].glyph === ' ' ? 1 : 0;
+
+					}
+					const additionalSpace = REMAINING_SPACE / validSpaces;
+
+					let offsetX = 0;
+					if( ALIGNMENT === 'justify' || ALIGNMENT === 'justify-left' ){
+
+						for ( let j = 1 ; j <= line.length - 1; j++ ) {
+							const char = line[ j ];
+							char.offsetX += offsetX;
+							offsetX += char.glyph === ' ' ? additionalSpace : 0;
+						}
+					}
+					else {
+
+						for ( let j = line.length - 2; j >= 0; j-- ) {
+							const char = line[ j ];
+							char.offsetX -= offsetX;
+							offsetX += char.glyph === ' ' ? additionalSpace : 0;
+						}
+
+					}
+
+				}
 
 			} );
 

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -28,7 +28,7 @@ export default function InlineManager( Base ) {
 
 			// got by MeshUIComponent
 			const JUSTIFICATION = this.getJustifyContent();
-			const ALIGNMENT = this.getAlignContent();
+			const ALIGNMENT = this.getTextAlign();
 
 			const INTERLINE = this.getInterLine();
 
@@ -92,20 +92,18 @@ export default function InlineManager( Base ) {
 
 			// Horizontal positioning
 
-			lines.forEach( ( line ) => {
+			lines.forEach( ( line, i, arr ) => {
 
 				const alignmentOffset = ( () => {
 
 					switch ( ALIGNMENT ) {
 
 						case 'left':
-							console.warn(`alignContent 'left' has been deprecated. Please rely on 'start' or 'end' instead`);
 							// fallthrough
 						case 'start':
 							return -INNER_WIDTH / 2;
 
 						case 'right':
-							console.warn(`alignContent 'left' has been deprecated. Please rely on 'start' or 'end' instead`);
 							// fallthrough
 						case 'end':
 							return -line.width + ( INNER_WIDTH / 2 );

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -5,6 +5,7 @@ import FontLibrary from './FontLibrary.js';
 import UpdateManager from './UpdateManager.js';
 
 import DEFAULTS from '../../utils/Defaults.js';
+import BoxComponent from './BoxComponent';
 
 /**
 
@@ -453,7 +454,9 @@ export default function MeshUIComponent( Base ) {
 
 			if ( !options || JSON.stringify( options ) === JSON.stringify( {} ) ) return;
 
-			//@deprecated
+			// DEPRECATION Warnings until -------------------------------------- 7.x.x ---------------------------------------
+
+			// Align content has been removed
 			if( options["alignContent"] ){
 
 				options["alignItems"] = options["alignContent"];
@@ -467,6 +470,13 @@ export default function MeshUIComponent( Base ) {
 				console.warn("`alignContent` property has been deprecated, please rely on `alignItems` and `textAlign` instead.")
 
 				delete options["alignContent"];
+
+			}
+
+			// Align items left top bottom right will be removed
+			if( options['alignItems'] ){
+
+				warnAboutDeprecatedAlignItems( options['alignItems'] );
 
 			}
 
@@ -627,5 +637,28 @@ export default function MeshUIComponent( Base ) {
 
 		}
 	};
+
+}
+
+// @TODO: Be remove upon 7.x.x
+const DEPRECATED_ALIGN_ITEMS = [
+	'top',
+	'right',
+	'bottom',
+	'left'
+]
+
+/**
+ * @deprecated
+ * // @TODO: Be remove upon 7.x.x
+ * @param alignment
+ */
+function warnAboutDeprecatedAlignItems( alignment ){
+
+	if( DEPRECATED_ALIGN_ITEMS.indexOf(alignment) !== - 1){
+
+		console.warn(`alignItems === '${alignment}' is deprecated and will be remove in 7.x.x. Fallback are 'start'|'end'`)
+
+	}
 
 }

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -181,6 +181,12 @@ export default function MeshUIComponent( Base ) {
 
 		}
 
+		getTextAlign() {
+
+			return this._getProperty( 'textAlign' );
+
+		}
+
 		getTextType() {
 
 			return this._getProperty( 'textType' );
@@ -294,9 +300,19 @@ export default function MeshUIComponent( Base ) {
 
 		}
 
+		/**
+		 * @deprecated
+		 * @returns {string}
+		 */
 		getAlignContent() {
 
 			return this.alignContent || DEFAULTS.alignContent;
+
+		}
+
+		getAlignItems() {
+
+			return this.alignItems || DEFAULTS.alignItems;
 
 		}
 
@@ -437,6 +453,19 @@ export default function MeshUIComponent( Base ) {
 
 			if ( !options || JSON.stringify( options ) === JSON.stringify( {} ) ) return;
 
+			//@deprecated
+			if( options["alignContent"] ){
+
+				options["alignItems"] = options["alignContent"];
+				options["textAlign"] = options["alignContent"];
+
+				console.warn("`alignContent` property has been deprecated, please rely on `alignItems` and `textAlign` instead.")
+
+				delete options["alignContent"];
+
+			}
+
+
 			// Set this component parameters according to options, and trigger updates accordingly
 			// The benefit of having two types of updates, is to put everthing that takes time
 			// in one batch, and the rest in the other. This way, efficient animation is possible with
@@ -485,6 +514,8 @@ export default function MeshUIComponent( Base ) {
 						case 'contentDirection' :
 						case 'justifyContent' :
 						case 'alignContent' :
+						case 'alignItems' :
+						case 'textAlign' :
 						case 'textType' :
 							layoutNeedsUpdate = true;
 							this[ prop ] = options[ prop ];

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -457,7 +457,12 @@ export default function MeshUIComponent( Base ) {
 			if( options["alignContent"] ){
 
 				options["alignItems"] = options["alignContent"];
-				options["textAlign"] = options["alignContent"];
+
+				if( !options["textAlign"] ){
+
+					options["textAlign"] = options["alignContent"];
+
+				}
 
 				console.warn("`alignContent` property has been deprecated, please rely on `alignItems` and `textAlign` instead.")
 

--- a/src/three-mesh-ui.js
+++ b/src/three-mesh-ui.js
@@ -6,6 +6,7 @@ import InlineBlock from './components/InlineBlock.js';
 import Keyboard from './components/Keyboard.js';
 import UpdateManager from './components/core/UpdateManager.js';
 import FontLibrary from './components/core/FontLibrary.js';
+import * as textAlign from './utils/TextAlign';
 
 const update = () => UpdateManager.update();
 
@@ -16,6 +17,7 @@ const ThreeMeshUI = {
 	Keyboard,
 	FontLibrary,
 	update,
+	textAlign
 };
 
 if ( typeof global !== 'undefined' ) global.ThreeMeshUI = ThreeMeshUI;
@@ -26,5 +28,6 @@ export { InlineBlock };
 export { Keyboard };
 export { FontLibrary };
 export { update };
+export { textAlign };
 
 export default ThreeMeshUI;

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -1,5 +1,8 @@
 import { Color } from 'three';
 import { CanvasTexture } from 'three';
+import { CENTER as textAlign } from './TextAlign';
+
+
 
 /** List the default values of the lib components */
 export default {
@@ -16,7 +19,7 @@ export default {
 	alignItems: 'center',
 	justifyContent: 'start',
 	fontTexture: null,
-	textAlign: "center",
+	textAlign,
 	textType: 'MSDF',
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,

--- a/src/utils/Defaults.js
+++ b/src/utils/Defaults.js
@@ -13,9 +13,10 @@ export default {
 	breakOn: '- ,.:?!\n',// added '\n' to also acts as friendly breaks when white-space:normal
 	whiteSpace: 'pre-line',
 	contentDirection: 'column',
-	alignContent: 'center',
+	alignItems: 'center',
 	justifyContent: 'start',
 	fontTexture: null,
+	textAlign: "center",
 	textType: 'MSDF',
 	fontColor: new Color( 0xffffff ),
 	fontOpacity: 1,

--- a/src/utils/TextAlign.js
+++ b/src/utils/TextAlign.js
@@ -1,0 +1,125 @@
+export const LEFT = 'left';
+export const RIGHT = 'right';
+export const CENTER = 'center';
+export const JUSTIFY = 'justify';
+export const JUSTIFY_LEFT = 'justify-left';
+export const JUSTIFY_RIGHT = 'justify-right';
+export const JUSTIFY_CENTER = 'justify-center';
+
+export function alignLines( lines, ALIGNMENT, INNER_WIDTH ) {
+
+	// Start the alignment by sticking to directions : left, right, center
+	for ( let i = 0; i < lines.length; i++ ) {
+
+		const line = lines[ i ];
+
+		// compute the alignment offset of the line
+		let offsetX = computeLineOffset( line, ALIGNMENT, INNER_WIDTH, i === lines.length - 1 );
+
+		// apply the offset to each characters of the line
+		for ( let j = 0; j < line.length; j++ ) {
+
+			line[ j ].offsetX += offsetX;
+
+		}
+
+	}
+
+	// last operations for justifications alignments
+	if ( ALIGNMENT.indexOf( JUSTIFY ) === 0 ) {
+
+		for ( let i = 0; i < lines.length; i++ ) {
+
+			const line = lines[ i ];
+
+
+			// do not process last line for justify-left or justify-right
+			if ( ALIGNMENT.indexOf( '-' ) !== -1 && i === lines.length - 1 ) return;
+
+			// can only justify is space is remaining
+			const REMAINING_SPACE = INNER_WIDTH - line.width;
+			if ( REMAINING_SPACE <= 0 ) return;
+
+			// count the valid spaces to extend
+			// Do not take the first nor the last space into account
+			let validSpaces = 0;
+			for ( let j = 1; j < line.length - 1; j++ ) {
+
+				validSpaces += line[ j ].glyph === ' ' ? 1 : 0;
+
+			}
+			const additionalSpace = REMAINING_SPACE / validSpaces;
+
+
+			// for right justification, process the loop in reverse
+			let inverter = 1;
+			if ( ALIGNMENT === JUSTIFY_RIGHT ) {
+
+				line.reverse();
+				inverter = -1;
+
+			}
+
+			let incrementalOffsetX = 0;
+
+			// start at ONE to avoid first space
+			for ( let j = 1; j <= line.length - 1; j++ ) {
+
+				// apply offset on each char
+				const char = line[ j ];
+				char.offsetX += incrementalOffsetX * inverter;
+
+				// and increase it when space
+				incrementalOffsetX += char.glyph === ' ' ? additionalSpace : 0;
+
+			}
+
+			// for right justification, the loop was processed in reverse
+			if ( ALIGNMENT === JUSTIFY_RIGHT ) {
+				line.reverse();
+			}
+
+
+		}
+
+	}
+
+}
+
+
+const computeLineOffset = ( line, ALIGNMENT, INNER_WIDTH, lastLine ) => {
+
+	switch ( ALIGNMENT ) {
+
+		case JUSTIFY_LEFT:
+		case JUSTIFY:
+		case LEFT:
+			return -INNER_WIDTH / 2;
+
+		case JUSTIFY_RIGHT:
+		case RIGHT:
+			return -line.width + ( INNER_WIDTH / 2 );
+
+
+		case CENTER:
+			return -line.width / 2;
+
+		case JUSTIFY_CENTER:
+			if ( lastLine ) {
+
+				// center alignement
+				return -line.width / 2;
+
+			} else {
+
+				// left alignment
+				return -INNER_WIDTH / 2;
+
+			}
+
+		default:
+			console.warn( `textAlign: '${ALIGNMENT}' is not valid` );
+
+	}
+
+};


### PR DESCRIPTION
Addressing #25 

Added justify-content : `space-around` , `space-between`, `space-evenly`

The implementation take the remaining space to distribute it accross children according to the defined value.

**Example :** 
Show for both content directions `row` and `column` the following justify-content property : `start`, `end`, `center`, `space between`, `space-around', `space-evenly`. 

It intervally alter alignContent to : `start`, `end`, `center`
It intervally change `row` to `row-reverse` and `column` to `column-reverse`
It intervally change the size of justified items. 

![image](https://user-images.githubusercontent.com/17314210/153599539-c1383093-8fbb-48b4-a4a2-fc4105a1c2e5.png)


Some related topics:

## start end confusion
When coding the interval to change `row` to `row-reverse`, I was a bit confuse because it didn't behave as I would have expected. The current justifyContent `end`/`start` implementations act as `flex-end` and `flex-start` in css. 

In terms of layouting possibilities, it doesn't have any impacts, as users still could manually inverse the justifyContent when direction is `-reverse`  in order to have the expected behaviour.

## Align of space-*
Alignment of `space-between`, `space-around`, `space-evenly` is currently on `{flex-}start`. Which means if children size is greater than inner, instead of being distributed, those property would stick to `start`

I still ask, but should we overlap items if the container is too narrow?

## Align content
I currently added `start`,`end` as valid align content values. It offers the ability to be used either in `column` or `row` direction.

When I onboarded with this library, I was trying to change my tests layouts from `row` to `column` and I found it a bit exhaustive to also require to update alignContent property accordingly. This led me to many warning when flipping layout direction.

But my current changes allowed me to notice that inlines also relies on `alignContent`. It provides the textAlign behaviour if I understood it correctly. So the proposition might not fit perfectly right now

## Warnings
Warnings are globally triggered during update when invalid value in context(row-column), or unavailable value. This can lead to performance downgrade and are triggered even when no direct set on the invalid property in done.

Could we dispatch warnings during `set()` instead?  and fallbacking to another valid value instead? This could save some warning during further update and keep user informed.


## Code location
As this is increasing `BoxComponent` source, and possibly related to `InlineManager` I wonder it would be better to place it in its own, just like `Whitespace.js`.