### PR TITLE
Js build update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Give it a try in [this jsFiddle](https://jsfiddle.net/felixmariotto/y81rf5t2/44/
 Using react-three-fiber ? Here is a [codesandbox](https://codesandbox.io/s/react-three-mesh-ui-forked-v7n0b?file=/src/index.js) to get started.
 
 ## Import
+### JSM
 **With NPM and ES6 :**   
 In your console : `npm install three-mesh-ui`
 ```javascript
@@ -51,10 +52,29 @@ In your console : `npm install three-mesh-ui`
 const ThreeMeshUI = require('three-mesh-ui');
 ```
 
-**With HTML <script> tag :**    
+**With HTML &lt;script&gt; tag :**
 ```html
+<script type="module">
+    import * as THREE from 'https://cdn.skypack.dev/three@<version>';
+    import * ThreeMeshUI from 'not-available-at-the-moment';
+    // We currently didn't have a bundled jsm file :,( 
+    // Please be welcome to contribute if this is something you use. :)
+</script>
+```
+
+
+### JS
+**With HTML &lt;script&gt; tag :**
+```html
+<!-- threejs is not anymore include in the three-mesh-ui bundle -->
+<!-- you must then load the three dependency -->
+<script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js'></script>
+<!-- before loading three-mesh-ui -->
 <script src='https://unpkg.com/three-mesh-ui'></script>
 ```
+
+*Although this would theorically allows you to build 'something', loading js libraries instead of using jsm, might restrict the global features you would have. This is true for both three and three-mesh-ui libraries.*
+
 
 ## Font files
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = env => {
 			filename: '[name].js',
 			library: 'ThreeMeshUI',
 			libraryTarget: 'umd'
+		},
+		externals: {
+			three:'THREE'
 		}
 
 	}


### PR DESCRIPTION
Threejs has been put as being an external dependency.

- It reduced the bundle size from ~590kb to ~64kb
- It allows user to load the threejs library version they want, without multiple threejs version warning

Readme file has been updated with both jsm and js sections. 

It may still lack an example with loading js library with `<script>` markup, but on threejs official site, they do not provide anymore documentation on how to use js library. Not sure it worth the shot, but im biaised.

This PR may provide sufficient changes to close #23 and #26 or at least a firt pass on this