### PR TITLE
export lines generated by inlines manager

### DIFF
--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -117,6 +117,10 @@ export default function InlineManager( Base ) {
 
 			} );
 
+
+			// Make lines accessible to provide helpful informations
+			this.lines = lines;
+
 		}
 
 


### PR DESCRIPTION
@felixmariotto 
When I did whitespace, I was already thinking about having the computed lines property to be available in order to ease the development. 

Next, I was thinking those lines property could also serve as a reliable basis for text-select raycast.

And now this could allow provide some workaround ( and further example behaviour ) on #166 

Are you agree on providing that property ?