### PR TITLE
change order of onAfterUpdate

### DIFF
--- a/src/components/core/UpdateManager.js
+++ b/src/components/core/UpdateManager.js
@@ -122,6 +122,9 @@ export default class UpdateManager {
 	static traverseUpdates( component ) {
 
 		const request = this.requestedUpdates[ component.id ];
+		// instant remove the requested update,
+		// allowing code below ( especially onAfterUpdate ) to add it without being directly remove
+		delete this.requestedUpdates[ component.id ];
 
 		//
 
@@ -143,25 +146,21 @@ export default class UpdateManager {
 
 		}
 
-		//
 
-		if ( request && request.needCallback ) {
-
-			component.onAfterUpdate();
-
-		}
-
-		//
-
-		delete this.requestedUpdates[ component.id ];
-
-		//
+		// Update any child
 
 		component.getUIChildren().forEach( ( childUI ) => {
 
 			this.traverseUpdates( childUI );
 
 		} );
+
+		// before sending onAfterUpdate
+		if ( request && request.needCallback ) {
+
+			component.onAfterUpdate();
+
+		}
 
 	}
 


### PR DESCRIPTION
Initial fix for #166 workaround. Might also fix #73 

- Remove the update request **before** onAfterUpdate execution, which allow onAfterUpdate to set properties.
- Order of traversing update and then onAfterUpdate on LIFO instead of FIFO. A Block now have all its children information when onAfterUpdate
