### PR TITLE
Compute children variants lists

### DIFF
--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -111,7 +111,7 @@ export default class Block extends mix.withBase( Object3D )(
 		// Position inner elements according to dimensions and layout parameters.
 		// Delegate to BoxComponent.
 
-		if ( this.children.find( child => child.isInline ) ) {
+		if ( this.childrenInlines.length ) {
 
 			this.computeInlinesPosition();
 

--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -63,17 +63,13 @@ export default class Block extends mix.withBase( Object3D )(
 
 		const bestFit = this.getBestFit();
 
-		if ( bestFit != 'none' && ( this.children.find( child => child.isText ) ) ) {
+		if ( bestFit != 'none' && this.childrenTexts.length ) {
 
 			this.calculateBestFit( bestFit );
 
 		} else {
 
-			this.children.filter( child => {
-
-				return child.isText;
-
-			} ).forEach( child => {
+			this.childrenTexts.forEach( child => {
 
 				child._fitFontSize = undefined;
 

--- a/src/components/InlineBlock.js
+++ b/src/components/InlineBlock.js
@@ -116,7 +116,7 @@ export default class InlineBlock extends mix.withBase( Object3D )(
 		// Position inner elements according to dimensions and layout parameters.
 		// Delegate to BoxComponent.
 
-		if ( this.children.find( child => child.isInline ) ) {
+		if ( this.childrenInlines.length ) {
 
 			this.computeInlinesPosition();
 

--- a/src/components/Keyboard.js
+++ b/src/components/Keyboard.js
@@ -284,9 +284,9 @@ export default class Keyboard extends mix.withBase( Object3D )( BoxComponent, Me
 
 			const newContent = this.isLowerCase || !char.upperCase ? char.lowerCase : char.upperCase;
 
-			const textComponent = key.children.find( child => child.isText );
+			if ( !key.childrenTexts.length ) return;
 
-			if ( !textComponent ) return;
+			const textComponent = key.childrenTexts[0];
 
 			key.info.input = newContent;
 
@@ -311,9 +311,9 @@ export default class Keyboard extends mix.withBase( Object3D )( BoxComponent, Me
 
 			const newContent = this.isLowerCase || !char.upperCase ? char.lowerCase : char.upperCase;
 
-			const textComponent = key.children.find( child => child.isText );
+			if ( !key.childrenTexts.length ) return;
 
-			if ( !textComponent ) return;
+			const textComponent = key.childrenTexts[0];
 
 			key.info.input = newContent;
 

--- a/src/components/core/BoxComponent.js
+++ b/src/components/core/BoxComponent.js
@@ -77,9 +77,7 @@ export default function BoxComponent( Base ) {
 		/** Return the sum of all this component's children sides + their margin */
 		getChildrenSideSum( dimension ) {
 
-			return this.children.reduce( ( accu, child ) => {
-
-				if ( !child.isBoxComponent ) return accu;
+			return this.childrenBoxes.reduce( ( accu, child ) => {
 
 				const margin = ( child.margin * 2 ) || 0;
 
@@ -148,9 +146,7 @@ export default function BoxComponent( Base ) {
 		 */
 		getHighestChildSizeOn( direction ) {
 
-			return this.children.reduce( ( accu, child ) => {
-
-				if ( !child.isBoxComponent ) return accu;
+			return this.childrenBoxes.reduce( ( accu, child ) => {
 
 				const margin = child.margin || 0;
 				const maxSize = direction === 'width' ?

--- a/src/components/core/InlineManager.js
+++ b/src/components/core/InlineManager.js
@@ -103,36 +103,30 @@ export default function InlineManager( Base ) {
 
 		calculateBestFit( bestFit ) {
 
-			const inlineChildren = this.children.filter( ( child ) => {
-
-				return child.isInline ? true : false;
-
-			} );
-
-			if ( inlineChildren.length === 0 ) return;
+			if ( this.childrenInlines.length === 0 ) return;
 
 			switch ( bestFit ) {
 				case 'grow':
-					this.calculateGrowFit( inlineChildren );
+					this.calculateGrowFit();
 					break;
 				case 'shrink':
-					this.calculateShrinkFit( inlineChildren );
+					this.calculateShrinkFit();
 					break;
 				case 'auto':
-					this.calculateAutoFit( inlineChildren );
+					this.calculateAutoFit();
 					break;
 			}
 
 		}
 
-		calculateGrowFit( inlineChildren ) {
+		calculateGrowFit() {
 
 			const INNER_HEIGHT = this.getHeight() - ( this.padding * 2 || 0 );
 
 			//Iterative method to find a fontSize of text children that text will fit into container
 			let iterations = 1;
 			const heightTolerance = 0.075;
-			const firstText = inlineChildren.find( inlineComponent => inlineComponent.isText );
+			const firstText = this.childrenInlines.find( inlineComponent => inlineComponent.isText );
 
 			let minFontMultiplier = 1;
 			let maxFontMultiplier = 2;
@@ -141,13 +135,13 @@ export default function InlineManager( Base ) {
 
 			do {
 
-				textHeight = this.calculateHeight( inlineChildren, fontMultiplier );
+				textHeight = this.calculateHeight( fontMultiplier );
 
 				if ( textHeight > INNER_HEIGHT ) {
 
 					if ( fontMultiplier <= minFontMultiplier ) { // can't shrink text
 
-						inlineChildren.forEach( inlineComponent => {
+						this.childrenInlines.forEach( inlineComponent => {
 
 							if ( inlineComponent.isInlineBlock ) return;
 
@@ -178,14 +172,14 @@ export default function InlineManager( Base ) {
 
 		}
 
-		calculateShrinkFit( inlineChildren ) {
+		calculateShrinkFit() {
 
 			const INNER_HEIGHT = this.getHeight() - ( this.padding * 2 || 0 );
 
 			// Iterative method to find a fontSize of text children that text will fit into container
 			let iterations = 1;
 			const heightTolerance = 0.075;
-			const firstText = inlineChildren.find( inlineComponent => inlineComponent.isText );
+			const firstText = this.childrenInlines.find( inlineComponent => inlineComponent.isText );
 
 			let minFontMultiplier = 0;
 			let maxFontMultiplier = 1;
@@ -194,7 +188,7 @@ export default function InlineManager( Base ) {
 
 			do {
 
-				textHeight = this.calculateHeight( inlineChildren, fontMultiplier );
+				textHeight = this.calculateHeight( fontMultiplier );
 
 				if ( textHeight > INNER_HEIGHT ) {
 
@@ -205,7 +199,7 @@ export default function InlineManager( Base ) {
 
 					if ( fontMultiplier >= maxFontMultiplier ) { // can't grow text
 
-						inlineChildren.forEach( inlineComponent => {
+						this.childrenInlines.forEach( inlineComponent => {
 
 							if ( inlineComponent.isInlineBlock ) return;
 
@@ -228,14 +222,14 @@ export default function InlineManager( Base ) {
 			} while ( ++iterations <= 10 );
 		}
 
-		calculateAutoFit( inlineChildren ) {
+		calculateAutoFit()  {
 
 			const INNER_HEIGHT = this.getHeight() - ( this.padding * 2 || 0 );
 
 			//Iterative method to find a fontSize of text children that text will fit into container
 			let iterations = 1;
 			const heightTolerance = 0.075;
-			const firstText = inlineChildren.find( inlineComponent => inlineComponent.isText );
+			const firstText = this.childrenInlines.find( inlineComponent => inlineComponent.isText );
 
 			let minFontMultiplier = 0;
 			let maxFontMultiplier = 2;
@@ -244,7 +238,7 @@ export default function InlineManager( Base ) {
 
 			do {
 
-				textHeight = this.calculateHeight( inlineChildren, fontMultiplier );
+				textHeight = this.calculateHeight( fontMultiplier );
 
 				if ( textHeight > INNER_HEIGHT ) {
 
@@ -278,12 +272,7 @@ export default function InlineManager( Base ) {
 			// correct lines position before to merge
 			const lines = [ [] ];
 
-			this.children.filter( ( child ) => {
-
-				return child.isInline ? true : false;
-
-			} )
-				.reduce( ( lastInlineOffset, inlineComponent ) => {
+			this.childrenInlines.reduce( ( lastInlineOffset, inlineComponent ) => {
 
 					// Abort condition
 
@@ -396,9 +385,9 @@ export default function InlineManager( Base ) {
 			return lines;
 		}
 
-		calculateHeight( inlineChildren, fontMultiplier ) {
+		calculateHeight( fontMultiplier ) {
 
-			inlineChildren.forEach( inlineComponent => {
+			this.childrenInlines.forEach( inlineComponent => {
 
 				if ( inlineComponent.isInlineBlock ) return;
 

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -31,6 +31,12 @@ export default function MeshUIComponent( Base ) {
 			this.isUI = true;
 			this.autoLayout = true;
 
+			// children
+			this.childrenUIs = [];
+			this.childrenBoxes = [];
+			this.childrenTexts = [];
+			this.childrenInlines = [];
+
 		}
 
 		/////////////
@@ -79,15 +85,15 @@ export default function MeshUIComponent( Base ) {
 
 		//
 
-		getUIChildren() {
-
-			return this.children.filter( ( child ) => {
-
-				return child.isUI;
-
-			} );
-
-		}
+		// getUIChildren() {
+		//
+		// 	return this.children.filter( ( child ) => {
+		//
+		// 		return child.isUI;
+		//
+		// 	} );
+		//
+		// }
 
 		//
 
@@ -364,6 +370,25 @@ export default function MeshUIComponent( Base ) {
 		///////////////
 
 		/**
+		 * Filters children in order to compute only one times children lists
+		 * @private
+		 */
+		_rebuildChildrenLists(){
+
+			// Stores all children that are ui
+			this.childrenUIs = this.children.filter( child => child.isUI );
+
+			// Stores all children that are box
+			this.childrenBoxes = this.children.filter( child => child.isBoxComponent );
+
+			// Stores all children that are inline
+			this.childrenInlines = this.children.filter( child => child.isInline );
+
+			// Stores all children that are text
+			this.childrenTexts = this.children.filter( child => child.isText );
+		}
+
+		/**
 		 * When the user calls component.add, it registers for updates,
 		 * then call THREE.Object3D.add.
 		 */
@@ -376,7 +401,11 @@ export default function MeshUIComponent( Base ) {
 
 			}
 
-			return super.add( ...arguments );
+			const result = super.add( ...arguments );
+
+			this._rebuildChildrenLists();
+
+			return result;
 
 		}
 
@@ -393,7 +422,11 @@ export default function MeshUIComponent( Base ) {
 
 			}
 
-			return super.remove( ...arguments );
+			const result =  super.remove( ...arguments );
+
+			this._rebuildChildrenLists();
+
+			return result;
 
 		}
 

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -359,7 +359,7 @@ export default function MeshUIComponent( Base ) {
 		 * Filters children in order to compute only one times children lists
 		 * @private
 		 */
-		_rebuildChildrenLists(){
+		_rebuildChildrenLists() {
 
 			// Stores all children that are ui
 			this.childrenUIs = this.children.filter( child => child.isUI );
@@ -408,7 +408,7 @@ export default function MeshUIComponent( Base ) {
 
 			}
 
-			const result =  super.remove( ...arguments );
+			const result = super.remove( ...arguments );
 
 			this._rebuildChildrenLists();
 

--- a/src/components/core/MeshUIComponent.js
+++ b/src/components/core/MeshUIComponent.js
@@ -83,20 +83,6 @@ export default function MeshUIComponent( Base ) {
 
 		}
 
-		//
-
-		// getUIChildren() {
-		//
-		// 	return this.children.filter( ( child ) => {
-		//
-		// 		return child.isUI;
-		//
-		// 	} );
-		//
-		// }
-
-		//
-
 		getUIParent() {
 
 			if ( this.parent && this.parent.isUI ) {

--- a/src/components/core/UpdateManager.js
+++ b/src/components/core/UpdateManager.js
@@ -111,7 +111,7 @@ export default class UpdateManager {
 
 		}
 
-		component.getUIChildren().forEach( child => this.traverseParsing( child ) );
+		component.childrenUIs.forEach( child => this.traverseParsing( child ) );
 
 	}
 
@@ -148,8 +148,7 @@ export default class UpdateManager {
 
 
 		// Update any child
-
-		component.getUIChildren().forEach( ( childUI ) => {
+		component.childrenUIs.forEach( ( childUI ) => {
 
 			this.traverseUpdates( childUI );
 

--- a/src/utils/block-layout/AlignItems.js
+++ b/src/utils/block-layout/AlignItems.js
@@ -25,9 +25,7 @@ export function alignItems( boxComponent, DIRECTION){
 	}
 	const AXIS_TARGET = ( boxComponent[getSizeMethod]() / 2 ) - ( boxComponent.padding || 0 );
 
-	boxComponent.children.forEach( ( child ) => {
-
-		if ( !child.isBoxComponent ) return;
+	boxComponent.childrenBoxes.forEach( ( child ) => {
 
 		let offset;
 

--- a/src/utils/block-layout/ContentDirection.js
+++ b/src/utils/block-layout/ContentDirection.js
@@ -5,9 +5,6 @@ export const COLUMN_REVERSE = "column-reverse";
 
 export function contentDirection( container, DIRECTION, startPos, REVERSE ){
 
-	// only work on boxChildren
-	const boxChildren = container.children.filter( _boxChildrenFilter );
-
 	// end to end children
 	let accu = startPos;
 
@@ -24,9 +21,9 @@ export function contentDirection( container, DIRECTION, startPos, REVERSE ){
 	}
 
 	// Refactor reduce into fori in order to get rid of this keyword
-	for ( let i = 0; i < boxChildren.length; i++ ) {
+	for ( let i = 0; i < container.childrenBoxes.length; i++ ) {
 
-		const child = boxChildren[ i ];
+		const child = container.childrenBoxes[ i ];
 
 		const CHILD_ID = child.id;
 		const CHILD_SIZE = child[childGetSize]();
@@ -45,6 +42,3 @@ export function contentDirection( container, DIRECTION, startPos, REVERSE ){
 	}
 
 }
-
-
-const _boxChildrenFilter = c => c.isBoxComponent;

--- a/src/utils/block-layout/JustifyContent.js
+++ b/src/utils/block-layout/JustifyContent.js
@@ -7,10 +7,6 @@ export const SPACE_EVENLY = 'space-evenly';
 
 export function justifyContent( boxComponent, direction, startPos, REVERSE){
 
-	// only work on boxChildren
-	const boxChildren = boxComponent.children.filter( _boxChildrenFilter );
-
-
 	const JUSTIFICATION = boxComponent.getJustifyContent();
 	if ( AVAILABLE_JUSTIFICATIONS.indexOf( JUSTIFICATION ) === -1 ) {
 
@@ -30,18 +26,16 @@ export function justifyContent( boxComponent, direction, startPos, REVERSE){
 	const justificationOffset = _getJustificationOffset( JUSTIFICATION, axisOffset );
 
 	// Items margin
-	const justificationMargins = _getJustificationMargin( boxChildren, remainingSpace, JUSTIFICATION, REVERSE );
+	const justificationMargins = _getJustificationMargin( boxComponent.childrenBoxes, remainingSpace, JUSTIFICATION, REVERSE );
 
 	// Apply
 	const axis = direction.indexOf( 'row' ) === 0 ? "x" : "y"
-	boxChildren.forEach( ( child , childIndex ) => {
+	boxComponent.childrenBoxes.forEach( ( child , childIndex ) => {
 
 		boxComponent.childrenPos[ child.id ][axis] -= justificationOffset - justificationMargins[childIndex];
 
 	} );
 }
-
-const _boxChildrenFilter = c => c.isBoxComponent;
 
 const AVAILABLE_JUSTIFICATIONS = [
 	START,


### PR DESCRIPTION
Splitting the layout logics #182 was also duplicating parts of code like : 

```javascript
// only work on Boxes
const boxChildren = boxComponent.children.filter( child => child.isBoxComponent );
```

Those calls also had variants : 
```javascript
// only work on Texts
const textChildren = boxComponent.children.filter( child => child.isText );
```

Those calls were possibly called more than once per frame, producing the same result. 
Those calls were also called on each update frame, possibly producing the same result.

Those listes are now computed once per structural change : When a child is added or removed    
And can be retrieve from any MeshUIComponent
```javascript
// children variants
this.childrenUIs = [];
this.childrenBoxes = [];
this.childrenTexts = [];
this.childrenInlines = [];
```

and every time a structural change happen

```javascript
_rebuildChildrenLists(){

    this.childrenUIs = this.children.filter( child => child.isUI );
    this.childrenBoxes = this.children.filter( child => child.isBoxComponent );
    this.childrenInlines = this.children.filter( child => child.isInline );
    this.childrenTexts = this.children.filter( child => child.isText );

}
```
