### PR TITLE
7.x.x feature Autogenerated TS Types 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "build/three-mesh-ui.min.js",
   "module": "build/three-mesh-ui.module.js",
-  "types": "build/types/three-mesh-ui.d.ts",
+  "types": "src/types.d.ts",
   "scripts": {
     "test": "echo \"No test specified yet\"",
     "lint": "eslint -c config/codestyle/.eslintrc src examples",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "node": "x.x.x"
   },
   "main": "build/three-mesh-ui.min.js",
-  "module": "build/three-mesh-ui.module.min.js",
-  "types": "src/types.d.ts",
+  "module": "build/three-mesh-ui.module.js",
+  "types": "build/types/three-mesh-ui.d.ts",
   "scripts": {
     "test": "echo \"No test specified yet\"",
     "lint": "eslint -c config/codestyle/.eslintrc src examples",

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -10,6 +10,11 @@ import { mix } from '../utils/mix.js';
 import * as Whitespace from '../utils/inline-layout/Whitespace';
 import FontFamily from '../font/FontFamily';
 import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import FontVariant from '../font/FontVariant.js'; 
+import MSDFInlineCharacter from '../font/msdf/MSDFInlineCharacter.js';
+/* eslint-enable no-unused-vars */
 
 /**
 

--- a/src/font/FontFamily.js
+++ b/src/font/FontFamily.js
@@ -1,5 +1,9 @@
 import { EventDispatcher } from 'three';
 import MSDFFontVariant from './msdf/MSDFFontVariant';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import FontVariant from './FontVariant';
+/* eslint-enable no-unused-vars */
 
 export default class FontFamily extends EventDispatcher {
 

--- a/src/font/FontLibrary.js
+++ b/src/font/FontLibrary.js
@@ -1,4 +1,8 @@
 import FontFamily from './FontFamily';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import FontVariant from './FontVariant';
+/* eslint-enable no-unused-vars */
 
 const _fontFamilies = {};
 

--- a/src/font/FontVariant.js
+++ b/src/font/FontVariant.js
@@ -1,5 +1,11 @@
 import { EventDispatcher } from 'three';
 import FontLibrary from './FontLibrary';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import TypographyFont from './TypographyFont';
+import MSDFTypographyCharacter from './msdf/MSDFTypographyCharacter';
+import InlineCharacter from './InlineCharacter';
+/* eslint-enable no-unused-vars */
 
 
 /**

--- a/src/font/InlineCharacter.js
+++ b/src/font/InlineCharacter.js
@@ -1,3 +1,8 @@
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import TypographyCharacter from "./TypographyCharacter";
+/* eslint-enable no-unused-vars */
+
 export default class InlineCharacter {
 
 	/**

--- a/src/font/TypographyCharacter.js
+++ b/src/font/TypographyCharacter.js
@@ -1,3 +1,9 @@
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import TypographyFont from "./TypographyFont";
+import InlineCharacter from "./InlineCharacter";
+/* eslint-enable no-unused-vars */
+
 /**
  * @abstract
  */

--- a/src/font/msdf/MSDFFontVariant.js
+++ b/src/font/msdf/MSDFFontVariant.js
@@ -3,7 +3,10 @@ import FontVariant from '../FontVariant';
 import MSDFTypographyFont from './MSDFTypographyFont';
 import MSDFTypographyCharacter from './MSDFTypographyCharacter';
 import MSDFGeometryCharacter from './MSDFGeometryCharacter';
-
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import MSDFInlineCharacter from './MSDFInlineCharacter';
+/* eslint-enable no-unused-vars */
 
 export default class MSDFFontVariant extends FontVariant {
 

--- a/src/font/msdf/MSDFGeometryCharacter.js
+++ b/src/font/msdf/MSDFGeometryCharacter.js
@@ -1,4 +1,8 @@
 import { PlaneBufferGeometry } from 'three';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import MSDFInlineCharacter from './MSDFInlineCharacter';
+/* eslint-enable no-unused-vars */
 
 export default class MSDFGeometryCharacter extends PlaneBufferGeometry {
 

--- a/src/font/msdf/MSDFInlineCharacter.js
+++ b/src/font/msdf/MSDFInlineCharacter.js
@@ -1,4 +1,8 @@
 import InlineCharacter from '../InlineCharacter';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import MSDFTypographyCharacter from './MSDFTypographyCharacter';
+/* eslint-enable no-unused-vars */
 
 export default class MSDFInlineCharacter extends InlineCharacter{
 

--- a/src/font/msdf/MSDFTypographyCharacter.js
+++ b/src/font/msdf/MSDFTypographyCharacter.js
@@ -1,5 +1,10 @@
 import TypographyCharacter from '../TypographyCharacter';
 import MSDFInlineCharacter from './MSDFInlineCharacter';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import MSDFTypographyFont from './MSDFTypographyFont';
+import { MSDFJsonChar } from '../FontVariant';
+/* eslint-enable no-unused-vars */
 
 export default class MSDFTypographyCharacter extends TypographyCharacter {
 

--- a/src/font/msdf/MSDFTypographyFont.js
+++ b/src/font/msdf/MSDFTypographyFont.js
@@ -1,4 +1,8 @@
 import TypographyFont from '../TypographyFont';
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import { MSDFJson } from '../FontVariant';
+/* eslint-enable no-unused-vars */
 
 export default class MSDFTypographyFont extends TypographyFont{
 

--- a/src/utils/inline-layout/TextAlign.js
+++ b/src/utils/inline-layout/TextAlign.js
@@ -1,3 +1,8 @@
+//JSDoc Related Imports
+/* eslint-disable no-unused-vars */
+import InlineCharacter from "../../font/InlineCharacter";
+/* eslint-enable no-unused-vars */
+
 export const LEFT = 'left';
 export const RIGHT = 'right';
 export const CENTER = 'center';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "build",
+    "outDir": "build/types",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": false


### PR DESCRIPTION
## Overview

The PR in its current state addresses the compiler issues laid out here https://github.com/felixmariotto/three-mesh-ui/issues/189#issuecomment-1101770029.

I fought a lot with this trying to find the best approach to incorporating types in the JSDocs parameters without adding too much clutter, while also keeping it more vanilla JS like. The solution of importing the modules referenced in param comments but not directly used in code seems like a middle ground solution. It isn't perfect but trying to go a more pure TS solution might be cumbersome to main contributors of the library. 

## Failed Import Directive Approach

I attempted to make a centralized typedefs file and define them all there, and then use the jsdoc import directive, but that in turn made it even more confusing to follow and ultimately went against the whole goal here. There are several outstanding tickets within the TS community to make this less of a headache, but it doesn't seem to be making much progress at the moment. 

```
//*.js file

/**
*
* @param {import("./MSDFTypographyCharacter").default} characterDesc
*/
constructor( characterDesc ) {
...
```

results in 
```
//*.d.ts file

 /**
 *
 * @param {import("./MSDFTypographyCharacter").default} characterDesc
 */
 constructor(characterDesc: import("./MSDFTypographyCharacter").default);
...
```

## Current PR Solution

Importing the types the way I do works, but without disabling the `no-unused-vars` checks for the imports, webpack will throw a ton of warnings that I don't think we would want. 

This PR also updates the out directory for the types to be in a dedicated `types` folder, and updates the package json to point to the entry *.d.ts file.

## Outstanding Issues

There are still some additional issues when I tried to use these type files in our main project. One major issue is we use `ThreeMeshUI.MeshUIComponent` all over to generalize Three Mesh UI Components like Text, Blocks, and InlineBlocks since it acts like a base class for these components. But the `MeshUIComponent.js` file exports `MeshUIComponent` as a function that returns a local class called `MeshUIComponent` . I'm currently unsure how to address this on our side, or on the three mesh UI side to make our code happy. I am open to ideas there, ultimately being able to refer to a base class for all component types would be preferred. 

Another issue with the current types I have yet to figure out is this error spit out by our build system when trying to use the new types generated: 

```
Error: node_modules/three-mesh-ui/build/types/font/FontFamily.d.ts:1:41 - error TS2315: Type 'EventDispatcher' is not generic.

1 export default class FontFamily extends EventDispatcher<import("three").Event> {
```

Any thoughts there would help.

## Final Thoughts

Lastly, I did not commit the types in their current form, yet at least. I am unsure as to how you guys go about the release process, and if we wanted to commit it or build it each time before publishing. Let me know how you would like to proceed there.

Thank you, I believe we are one step closer to having useful TS Types, but understand if this needs to be discussed further overall.