### PR TITLE
Use PlaneGeometry instead of PlaneBufferGeometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "peerDependencies": {
-    "three": ">=0.132.1"
+    "three": ">=0.144.0"
   }
 }

--- a/src/content/MSDFGlyph.js
+++ b/src/content/MSDFGlyph.js
@@ -1,11 +1,11 @@
-import { PlaneBufferGeometry } from 'three';
+import { PlaneGeometry } from 'three';
 
 /**
  * Job: create a plane geometry with the right UVs to map the MSDF texture on the wanted glyph.
  *
  * Knows: dimension of the plane to create, specs of the font used, glyph requireed
  */
-export default class MSDFGlyph extends PlaneBufferGeometry {
+export default class MSDFGlyph extends PlaneGeometry {
 
 	constructor( inline, font ) {
 


### PR DESCRIPTION
Minor change for issue #226 to handle newer versions of three.js deprecating *BufferGeometry naming in lieu of *Geometry

I did not update the files in the build folder as I noticed it was pulling in many changes unrelated to this pull request