### PR TITLE
Patch 1

### DIFF
--- a/examples/interactive_button.js
+++ b/examples/interactive_button.js
@@ -146,7 +146,7 @@ function init() {
 	);
 
 	const box = new THREE.Mesh(
-		new THREE.BoxBufferGeometry( 0.45, 0.45, 0.45 ),
+		new THREE.BoxGeometry( 0.45, 0.45, 0.45 ),
 		new THREE.MeshStandardMaterial( { color: 0x643de3, flatShading: true } )
 	);
 

--- a/examples/utils/VRControl.js
+++ b/examples/utils/VRControl.js
@@ -22,7 +22,7 @@ export default function VRControl( renderer ) {
 		transparent: true
 	} );
 
-	const geometry = new THREE.BoxBufferGeometry( 0.004, 0.004, 0.35 );
+	const geometry = new THREE.BoxGeometry( 0.004, 0.004, 0.35 );
 
 	geometry.translate( 0, 0, -0.15 );
 


### PR DESCRIPTION
Renamed BoxBufferGeometry to BoxGeometry as this is producing warning in console.
`THREE.BoxBufferGeometry has been renamed to THREE.BoxGeometry.`