### PR TITLE
Use mergeGeometries instead of mergeBufferGeometries

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "peerDependencies": {
-    "three": ">=0.144.0"
+    "three": ">=0.151.0"
   }
 }

--- a/src/content/MSDFText.js
+++ b/src/content/MSDFText.js
@@ -1,5 +1,5 @@
 import { Mesh } from 'three';
-import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 
 import MSDFGlyph from './MSDFGlyph.js';
 
@@ -103,7 +103,7 @@ function buildText() {
 
 	} );
 
-	const mergedGeom = mergeBufferGeometries( translatedGeom );
+	const mergedGeom = mergeGeometries( translatedGeom );
 
 	const mesh = new Mesh( mergedGeom, this.getFontMaterial() );
 


### PR DESCRIPTION
Thank you for maintaining awesome library.

Since r151 `mergeGeometries` is preferrable.

https://github.com/mrdoob/three.js/pull/25652

I checked past PR which addressed similar deprecation warn https://github.com/felixmariotto/three-mesh-ui/pull/230
I believe this library encourages users to update three.js version so I've updated package.json instead of keeping backward compatibility like the following:

```typescript
import BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';

const mergeGeometries =
	BufferGeometryUtils.mergeGeometries ||
	BufferGeometryUtils.mergeBufferGeometries;
```

Please let me know if you have a concern.